### PR TITLE
REL: Bump version to v104.0.1

### DIFF
--- a/bc/Backgrounds/Backgrounds.d.ts
+++ b/bc/Backgrounds/Backgrounds.d.ts
@@ -1,4 +1,9 @@
-declare function BackgroundsTextGet(msg: any): string;
+/**
+ * Returns the localized name for a given background
+ * @param {string} msg
+ * @returns {string}
+ */
+declare function BackgroundsTextGet(msg: string): string;
 /**
  * Builds the selectable background arrays based on the tags supplied
  * @param {readonly BackgroundTag[]} BackgroundTagList - An array of string of all the tags to load

--- a/bc_data/package.json
+++ b/bc_data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-data",
-  "version": "104.0.0",
+  "version": "104.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-stubs",
-  "version": "104.0.0",
+  "version": "104.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"


### PR DESCRIPTION
BC Version: R104
Repo: https://gitgud.io/bananarama92/Bondage-College.git
Branch: `typtyptyp`
Commit: `b3797c56a2dc8fd94a5ae4ee1b36f3124fdbb183`

Cherry picked [BondageProjects/Bondage-College#5043](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5043):
> **Add missing jsdoc comment to BackgroundsTextGet which messes up bc-stub**
> Otherwise it shows up as `any` there
