### PR TITLE
BUG: Ensure that namespace-embedded functions have generated docstrings

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -81,10 +81,15 @@ jobs:
           cd Bondage-College/BondageClub
           cp ../../.github/tsconfig.json tsconfig.json
 
+          # Extract all native .d.ts files and store them in a dedicated directory
           mkdir -p dist/NativeDeclarations
           find . -iname "*.d.ts" -not -path "./Scripts/lib/*" -not -path "./Tools/*" -not -path "./Screens/MiniGame/KinkyDungeon/*" -exec cp {} dist/NativeDeclarations/ \;
           cp ../../.github/lzstring.d.ts dist/NativeDeclarations/
           rm dist/NativeDeclarations/MessagesPatch.d.ts
+
+          # Convert namespace-embedded functions into proper methods so that TS actually picks up their docstrings
+          # (xref https://github.com/bananarama92/BC-stubs/issues/18)
+          python ../../namespace_function_sanitize.py .
 
           set +e
           npx -p typescript tsc

--- a/bc/Screens/Character/Login/Login.d.ts
+++ b/bc/Screens/Character/Login/Login.d.ts
@@ -174,8 +174,8 @@ declare var LoginErrorMessage: string;
 declare var LoginCharacter: NPCCharacter;
 declare let LoginTextCacheUnsubscribeCallback: any;
 declare namespace LoginEventListeners {
-    let _KeyDownInputName: (this: HTMLInputElement, ev: KeyboardEvent) => void;
-    let _KeyDownInputPassword: (this: HTMLInputElement, ev: KeyboardEvent) => void;
+    function _KeyDownInputName(this: HTMLInputElement, ev: KeyboardEvent): void;
+    function _KeyDownInputPassword(this: HTMLInputElement, ev: KeyboardEvent): void;
 }
 /**
  * The list of item fixups to apply on login.

--- a/bc/Screens/Online/ChatRoom/ChatRoom.d.ts
+++ b/bc/Screens/Online/ChatRoom/ChatRoom.d.ts
@@ -1500,9 +1500,30 @@ declare namespace ChatRoomSep {
     let ActiveElem: null | HTMLDivElement;
     let _ClickCollapse: (this: HTMLButtonElement, event: MouseEvent | TouchEvent) => Promise<void>;
     let _ClickScrollUp: (this: HTMLButtonElement, event: MouseEvent | TouchEvent) => Promise<void>;
+    /**
+     * Return a {@link HTMLElement.InnerHTML} representation of the passed button's room name
+     * @private
+     * @param {HTMLButtonElement} button
+     * @returns {string}
+     */
     function _GetDisplayName(button: HTMLButtonElement): string;
+    /**
+     * Create a dividing element serving as seperator for different chat rooms
+     * @param {boolean} appendChat - Whether to assign {@link ChatRoomSep.ActiveElem} and append the returned `<div>` to the chat log
+     * @returns {HTMLDivElement} - The created `<div>` element
+     */
     function Create(appendChat?: boolean): HTMLDivElement;
+    /**
+     * Return a {@link HTMLElement.innerHTML} representation of the separators room name
+     * @param {HTMLDivElement} roomSep - The chat room separator
+     * @returns {string}
+     */
     function GetDisplayName(roomSep: HTMLDivElement): string;
+    /**
+     * Return whether the passed room separator is collapsed OR NOT
+     * @param {HTMLDivElement} roomSep - The chat room separator
+     * @returns {boolean}
+     */
     function IsCollapsed(roomSep: HTMLDivElement): boolean;
     function Uncollapse(roomSep: HTMLDivElement): Promise<void>;
     function Collapse(roomSep: HTMLDivElement): Promise<void>;

--- a/bc/Screens/Room/Crafting/Crafting.d.ts
+++ b/bc/Screens/Room/Crafting/Crafting.d.ts
@@ -273,36 +273,74 @@ declare namespace CraftingDescription {
     let ExtendedDescriptionMarker: "\0";
     let Pattern: RegExp;
     let PatternASCII: RegExp;
+    /**
+     * Decode and return the passed string if it consists of UTF16-encoded UTF8 characters.
+     *
+     * Encoded strings must be marked with a leading {@link CraftingDescription.ExtendedDescriptionMarker}; unencoded strings are returned unmodified.
+     * @param {string} description - The to-be decoded string
+     * @returns {string} - The decoded string
+     */
     function Decode(description: string): string;
+    /**
+     * Encode the passed crafted item description, extracting all UTF8 characters and encoding up to two of them into a single UTF16 character.
+     *
+     * The first character is marked with {@link CraftingDescription.ExtendedDescriptionMarker}
+     * @param {string} description - The initial length <=398 string of UTF8 characters
+     * @returns {string} - The length <=200 string of UTF16-encoded UTF8 characters
+     */
     function Encode(description: string): string;
 }
 declare namespace CraftingEventListeners {
-    let _ClickPrivate: (this: HTMLInputElement, ev: Event) => void;
-    let _InputLayering: (this: HTMLInputElement, ev: Event) => void;
-    let _ChangeName: (this: HTMLInputElement, ev: Event) => void;
-    let _ChangeDescription: (this: HTMLTextAreaElement, ev: Event) => void;
-    let _InputDescription: (this: HTMLTextAreaElement, ev: Event) => void;
-    let _ChangeColor: (this: HTMLInputElement, ev: Event) => void;
-    let _ClickExtended: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickTighten: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickLayering: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickColors: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickUndress: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickAccept: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickExit: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickUpload: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickDownload: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickExpand: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickProperty: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickPadlock: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickAsset: (this: HTMLButtonElement, ev: Event) => void;
-    let _ClickRadio: (this: HTMLButtonElement, ev: Event) => void;
+    function _ClickPrivate(this: HTMLInputElement, ev: Event): void;
+    function _InputLayering(this: HTMLInputElement, ev: Event): void;
+    function _ChangeName(this: HTMLInputElement, ev: Event): void;
+    function _ChangeDescription(this: HTMLTextAreaElement, ev: Event): void;
+    function _InputDescription(this: HTMLTextAreaElement, ev: Event): void;
+    function _ChangeColor(this: HTMLInputElement, ev: Event): void;
+    function _ClickExtended(this: HTMLButtonElement, ev: Event): void;
+    function _ClickTighten(this: HTMLButtonElement, ev: Event): void;
+    function _ClickLayering(this: HTMLButtonElement, ev: Event): void;
+    function _ClickColors(this: HTMLButtonElement, ev: Event): void;
+    function _ClickUndress(this: HTMLButtonElement, ev: Event): void;
+    function _ClickAccept(this: HTMLButtonElement, ev: Event): void;
+    function _ClickExit(this: HTMLButtonElement, ev: Event): void;
+    function _ClickUpload(this: HTMLButtonElement, ev: Event): void;
+    function _ClickDownload(this: HTMLButtonElement, ev: Event): void;
+    function _ClickExpand(this: HTMLButtonElement, ev: Event): void;
+    function _ClickProperty(this: HTMLButtonElement, ev: Event): void;
+    function _ClickPadlock(this: HTMLButtonElement, ev: Event): void;
+    function _ClickAsset(this: HTMLButtonElement, ev: Event): void;
+    function _ClickRadio(this: HTMLButtonElement, ev: Event): void;
     let _InputSearch: (this: HTMLInputElement, ev: Event) => Promise<void>;
-    let _ClickAsciiDescription: (this: HTMLInputElement, ev: Event) => void;
+    function _ClickAsciiDescription(this: HTMLInputElement, ev: Event): void;
 }
 declare namespace CraftingElements {
+    /**
+     * @private
+     * @param {string} controls
+     * @returns {() => string[]}
+     */
     function _SearchInputGetDataList(controls: string): () => string[];
+    /**
+     * @private
+     * @param {string} id
+     * @param {string} controls
+     * @param {string} placeholder
+     * @returns {HTMLInputElement}
+     */
     function _SearchInput(id: string, controls: string, placeholder: string): HTMLInputElement;
+    /**
+     * @private
+     * @param {string} id
+     * @param {(this: HTMLButtonElement, ev: Event) => any} onClick
+     * @param {null | Asset} assetImage
+     * @param {null | Partial<Record<string, string | number | boolean>>} dataAttributes
+     * @param {null | string} label
+     * @param {null | readonly (string | Node)[]} children
+     * @param {null | Asset} asset
+     * @param {boolean} first
+     * @returns {HTMLButtonElement}
+     */
     function _RadioButton(id: string, onClick: (this: HTMLButtonElement, ev: Event) => any, assetImage?: null | Asset, dataAttributes?: null | Partial<Record<string, string | number | boolean>>, label?: null | string, children?: null | readonly (string | Node)[], asset?: null | Asset, first?: boolean): HTMLButtonElement;
 }
 /**

--- a/bc/Screens/Room/Platform/Platform.d.ts
+++ b/bc/Screens/Room/Platform/Platform.d.ts
@@ -438,7 +438,7 @@ declare var PlatformInventoryList: {
     Name: string;
     DisplayName: string;
     Description: string;
-    OnGive: (Char: any) => void;
+    OnGive(Char: any): void;
 }[];
 declare var PlatformTemplate: ({
     Name: string;
@@ -724,7 +724,7 @@ declare var PlatformTemplate: ({
         Damage?: undefined;
         JumpForce?: undefined;
     })[];
-    OnBind: () => void;
+    OnBind(): void;
     Magic?: undefined;
     MagicPerLevel?: undefined;
     ProjectileHitAudio?: undefined;
@@ -889,7 +889,7 @@ declare var PlatformTemplate: ({
         Cycle: number[];
         Speed: number;
     }[];
-    OnBind: () => void;
+    OnBind(): void;
     Perk?: undefined;
     PerkName?: undefined;
     HealthPerLevel?: undefined;
@@ -949,7 +949,7 @@ declare var PlatformTemplate: ({
         Cycle: number[];
         Speed: number;
     }[];
-    OnBind: () => void;
+    OnBind(): void;
     Perk?: undefined;
     PerkName?: undefined;
     HealthPerLevel?: undefined;
@@ -997,7 +997,7 @@ declare var PlatformTemplate: ({
         Cycle: number[];
         Speed: number;
     }[];
-    OnBind: () => void;
+    OnBind(): void;
     Perk?: undefined;
     PerkName?: undefined;
     HealthPerLevel?: undefined;
@@ -1044,7 +1044,7 @@ declare var PlatformTemplate: ({
         Cycle: number[];
         Speed: number;
     }[];
-    OnBind: () => void;
+    OnBind(): void;
     Perk?: undefined;
     PerkName?: undefined;
     HealthPerLevel?: undefined;
@@ -1123,7 +1123,7 @@ declare var PlatformTemplate: ({
         Damage: number[];
         Speed: number;
     }[];
-    OnBind: () => void;
+    OnBind(): void;
     Perk?: undefined;
     PerkName?: undefined;
     HealthPerLevel?: undefined;
@@ -1175,7 +1175,7 @@ declare var PlatformTemplate: ({
         Name: string;
         Speed: number;
     }[];
-    OnBind: () => void;
+    OnBind(): void;
     Perk?: undefined;
     PerkName?: undefined;
     HealthPerLevel?: undefined;
@@ -1318,7 +1318,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     Music: string;
@@ -1346,7 +1346,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     AlternateBackground: string;
@@ -1402,7 +1402,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     Music: string;
@@ -1426,7 +1426,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     Music: string;
@@ -1450,7 +1450,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     AlternateBackground: string;
@@ -1474,7 +1474,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     Music: string;
@@ -1498,7 +1498,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     Music: string;
@@ -1526,7 +1526,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     BackgroundFilter: string;
@@ -1554,7 +1554,7 @@ declare var PlatformRoomList: ({
     AlternateBackground?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     BackgroundFilter: string;
@@ -1606,7 +1606,7 @@ declare var PlatformRoomList: ({
     AlternateBackground?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     BackgroundFilter: string;
@@ -1630,7 +1630,7 @@ declare var PlatformRoomList: ({
     AlternateBackground?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     BackgroundFilter: string;
@@ -1743,7 +1743,7 @@ declare var PlatformRoomList: ({
     Name: string;
     Background: string;
     Music: string;
-    Entry: () => void;
+    Entry(): void;
     Text?: undefined;
     Width?: undefined;
     Height?: undefined;
@@ -1775,7 +1775,7 @@ declare var PlatformRoomList: ({
     Background: string;
     AlternateBackground: string;
     Music: string;
-    Entry: () => void;
+    Entry(): void;
     Width: number;
     Height: number;
     LimitLeft: number;
@@ -1795,7 +1795,7 @@ declare var PlatformRoomList: ({
     BackgroundFilter?: undefined;
 } | {
     Name: string;
-    Entry: () => void;
+    Entry(): void;
     Text: string;
     Background: string;
     Music: string;
@@ -1837,7 +1837,7 @@ declare var PlatformRoomList: ({
     Background: string;
     AlternateBackground: string;
     Music: string;
-    Entry: () => void;
+    Entry(): void;
     Width: number;
     Height: number;
     LimitLeft: number;
@@ -1865,7 +1865,7 @@ declare var PlatformRoomList: ({
     Background: string;
     AlternateBackground: string;
     Music: string;
-    Entry: () => void;
+    Entry(): void;
     Width: number;
     Height: number;
     LimitLeft: number;
@@ -1892,7 +1892,7 @@ declare var PlatformRoomList: ({
     Height: number;
     LimitRight: number;
     Heal: number;
-    Entry: () => void;
+    Entry(): void;
     Door: {
         Name: string;
         FromX: number;
@@ -1933,7 +1933,7 @@ declare var PlatformRoomList: ({
         ToX: number;
         ToFaceLeft?: undefined;
     })[];
-    Entry: () => void;
+    Entry(): void;
     Character: {
         Name: string;
         Status: string;
@@ -2007,7 +2007,7 @@ declare var PlatformRoomList: ({
         ToX: number;
         ToFaceLeft?: undefined;
     })[];
-    Entry: () => void;
+    Entry(): void;
     LimitLeft?: undefined;
     LimitRight?: undefined;
     Heal?: undefined;

--- a/bc/Screens/Room/PlatformDialog/PlatformDialog.d.ts
+++ b/bc/Screens/Room/PlatformDialog/PlatformDialog.d.ts
@@ -634,7 +634,7 @@ declare var PlatformDialogData: ({
         TextScript?: undefined;
         AudioScript?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -757,7 +757,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
         Entry?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Audio: string;
         Character: {
@@ -1128,8 +1128,8 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         Answer?: undefined;
     } | {
-        TextScript: () => "Is it you Melody?  Are you a zombie?" | "Hey!  I'm Edlaran, a wood elf, are you a zombie?";
-        AudioScript: () => "11" | "12";
+        TextScript(): "Is it you Melody?  Are you a zombie?" | "Hey!  I'm Edlaran, a wood elf, are you a zombie?";
+        AudioScript(): "11" | "12";
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -1284,7 +1284,7 @@ declare var PlatformDialogData: ({
             Script?: undefined;
         } | {
             Text: string;
-            Script: () => void;
+            Script(): void;
             Reply?: undefined;
             Audio?: undefined;
             AudioStyle?: undefined;
@@ -1465,7 +1465,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -1751,7 +1751,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -1879,7 +1879,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Background?: undefined;
         Character?: undefined;
@@ -1888,7 +1888,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         ID: string;
         Text: string;
         Character: {
@@ -1978,7 +1978,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         Text: string;
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Audio?: undefined;
@@ -1999,7 +1999,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         Entry?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -2022,7 +2022,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         Entry?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         ID: string;
         Text: string;
         Character: {
@@ -2059,7 +2059,7 @@ declare var PlatformDialogData: ({
             Script?: undefined;
         } | {
             Text: string;
-            Script: () => void;
+            Script(): void;
             Reply?: undefined;
         })[];
         Background?: undefined;
@@ -2847,8 +2847,8 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        TextScript: () => "My dear Olivia, together we are unstoppable." | "Olivia, I'm glad we are in this mess together." | "Little lady, I'll be there to lock you up every night." | "Olivia, I'll be there to protect you." | "Lady Olivia, your maid will be there to serve and obey you.  (You do a maid curtsy.)" | "Lady Olivia, I'll be there to help you.";
-        AudioScript: () => "81" | "82" | "83" | "84" | "85" | "86";
+        TextScript(): "My dear Olivia, together we are unstoppable." | "Olivia, I'm glad we are in this mess together." | "Little lady, I'll be there to lock you up every night." | "Olivia, I'll be there to protect you." | "Lady Olivia, your maid will be there to serve and obey you.  (You do a maid curtsy.)" | "Lady Olivia, I'll be there to help you.";
+        AudioScript(): "81" | "82" | "83" | "84" | "85" | "86";
         Character: {
             Name: string;
             Status: string;
@@ -2862,7 +2862,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -2955,7 +2955,7 @@ declare var PlatformDialogData: ({
     Exit: () => void;
     Dialog: ({
         Background: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -3061,7 +3061,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
     } | {
         ID: string;
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3074,7 +3074,7 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         Answer?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3095,7 +3095,7 @@ declare var PlatformDialogData: ({
     Exit: () => void;
     Dialog: ({
         Background: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -3182,7 +3182,7 @@ declare var PlatformDialogData: ({
             Audio: string;
             AudioStyle: string;
             Love: number;
-            Script: () => void;
+            Script(): void;
             Perk?: undefined;
         } | {
             Text: string;
@@ -3232,7 +3232,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
     } | {
         ID: string;
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3245,7 +3245,7 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         Answer?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3259,7 +3259,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3280,7 +3280,7 @@ declare var PlatformDialogData: ({
     Exit: () => void;
     Dialog: ({
         Background: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         AudioStyle?: undefined;
@@ -3363,7 +3363,7 @@ declare var PlatformDialogData: ({
             Reply: string;
             Audio: string;
             Domination: number;
-            Script: () => void;
+            Script(): void;
         } | {
             Text: string;
             Reply: string;
@@ -3378,7 +3378,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
     } | {
         ID: string;
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3391,7 +3391,7 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         Answer?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3406,7 +3406,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -3658,7 +3658,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         AudioStyle?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -3671,7 +3671,7 @@ declare var PlatformDialogData: ({
         Answer: ({
             Text: string;
             Reply: string;
-            Script: () => void;
+            Script(): void;
             Domination?: undefined;
             Love?: undefined;
         } | {
@@ -3707,7 +3707,7 @@ declare var PlatformDialogData: ({
         Text: string;
         Audio: string;
         AudioStyle: string;
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Answer?: undefined;
@@ -3790,7 +3790,7 @@ declare var PlatformDialogData: ({
         Audio: string;
         Answer: ({
             Text: string;
-            Script: () => void;
+            Script(): void;
             Domination?: undefined;
             Love?: undefined;
             Reply?: undefined;
@@ -3798,12 +3798,12 @@ declare var PlatformDialogData: ({
             Text: string;
             Domination: number;
             Love: number;
-            Script: () => void;
+            Script(): void;
             Reply?: undefined;
         } | {
             Text: string;
             Reply: string;
-            Script: () => void;
+            Script(): void;
             Domination?: undefined;
             Love?: undefined;
         })[];
@@ -3943,10 +3943,10 @@ declare var PlatformDialogData: ({
             Status: string;
             Pose: string;
         }[];
-        Entry: () => void;
+        Entry(): void;
         TextScript?: undefined;
     } | {
-        TextScript: () => "(The crate is open and empty.)" | "(It's too dangerous to inspect the crate while it's guarded.)";
+        TextScript(): "(The crate is open and empty.)" | "(It's too dangerous to inspect the crate while it's guarded.)";
         Background?: undefined;
         Character?: undefined;
         Entry?: undefined;
@@ -3982,10 +3982,10 @@ declare var PlatformDialogData: ({
         Answer: ({
             Text: string;
             Reply: string;
-            Script: () => void;
+            Script(): void;
         } | {
             Text: string;
-            Script: () => void;
+            Script(): void;
             Reply?: undefined;
         })[];
         Background?: undefined;
@@ -4050,7 +4050,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -4214,7 +4214,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -4446,7 +4446,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text?: undefined;
         Character?: undefined;
         Audio?: undefined;
@@ -4518,7 +4518,7 @@ declare var PlatformDialogData: ({
         Entry?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -4579,7 +4579,7 @@ declare var PlatformDialogData: ({
         Text: string;
         Answer: ({
             Text: string;
-            Script: () => void;
+            Script(): void;
             Reply?: undefined;
         } | {
             Text: string;
@@ -4609,7 +4609,7 @@ declare var PlatformDialogData: ({
         Audio?: undefined;
         Entry?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Background?: undefined;
         Character?: undefined;
@@ -5089,7 +5089,7 @@ declare var PlatformDialogData: ({
             Script?: undefined;
         } | {
             Text: string;
-            Script: () => void;
+            Script(): void;
             Reply?: undefined;
             Love?: undefined;
         })[];
@@ -5183,7 +5183,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         Entry?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -5198,7 +5198,7 @@ declare var PlatformDialogData: ({
     Exit: () => void;
     Dialog: ({
         Background: string;
-        Entry: () => void;
+        Entry(): void;
         Prerequisite?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -5207,7 +5207,7 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         Character: {
@@ -5294,7 +5294,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -5307,7 +5307,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         AudioStyle?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -5328,7 +5328,7 @@ declare var PlatformDialogData: ({
     Exit: () => void;
     Dialog: ({
         Background: string;
-        Entry: () => void;
+        Entry(): void;
         Prerequisite?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -5337,7 +5337,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         Character: {
@@ -5351,7 +5351,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -5452,7 +5452,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -5465,7 +5465,7 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         Answer?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -5486,7 +5486,7 @@ declare var PlatformDialogData: ({
     Exit: () => void;
     Dialog: ({
         Background: string;
-        Entry: () => void;
+        Entry(): void;
         Prerequisite?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -5495,7 +5495,7 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         Character: {
@@ -5583,7 +5583,7 @@ declare var PlatformDialogData: ({
             Audio: string;
             Domination: number;
             Love: number;
-            Script: () => void;
+            Script(): void;
         } | {
             Text: string;
             Reply: string;
@@ -5607,7 +5607,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -5620,7 +5620,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         AudioStyle?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -5635,7 +5635,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Character: {
             Name: string;
             Status: string;
@@ -5783,7 +5783,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -5797,7 +5797,7 @@ declare var PlatformDialogData: ({
         Audio?: undefined;
         Answer?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Character: {
             Name: string;
@@ -5809,8 +5809,8 @@ declare var PlatformDialogData: ({
         Audio?: undefined;
         Answer?: undefined;
     } | {
-        Prerequisite: () => boolean;
-        Entry: () => void;
+        Prerequisite(): boolean;
+        Entry(): void;
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -5861,7 +5861,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -5876,7 +5876,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Character: {
             Name: string;
@@ -5891,7 +5891,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Entry?: undefined;
         Character?: undefined;
@@ -5963,7 +5963,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -5978,7 +5978,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -6061,7 +6061,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -6075,7 +6075,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6115,7 +6115,7 @@ declare var PlatformDialogData: ({
             Reply: string;
             Audio: string;
             AudioStyle: string;
-            Script: () => void;
+            Script(): void;
             Goto?: undefined;
         } | {
             Text: string;
@@ -6130,7 +6130,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6154,7 +6154,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -6167,7 +6167,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6181,7 +6181,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6259,7 +6259,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6310,7 +6310,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6320,7 +6320,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -6333,7 +6333,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6406,7 +6406,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6442,7 +6442,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Character?: undefined;
         Audio?: undefined;
@@ -6466,7 +6466,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -6479,7 +6479,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6519,7 +6519,7 @@ declare var PlatformDialogData: ({
             Reply: string;
             Audio: string;
             AudioStyle: string;
-            Script: () => void;
+            Script(): void;
             Goto?: undefined;
         } | {
             Text: string;
@@ -6548,7 +6548,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6567,7 +6567,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -6580,7 +6580,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6595,7 +6595,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Character: {
             Name: string;
@@ -6610,7 +6610,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Entry?: undefined;
         Character?: undefined;
@@ -6672,7 +6672,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6687,7 +6687,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6798,7 +6798,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -6812,7 +6812,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6842,7 +6842,7 @@ declare var PlatformDialogData: ({
             Reply: string;
             Audio: string;
             AudioStyle: string;
-            Script: () => void;
+            Script(): void;
             Goto?: undefined;
         } | {
             Text: string;
@@ -6858,7 +6858,7 @@ declare var PlatformDialogData: ({
         AudioStyle?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6891,7 +6891,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -6904,7 +6904,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -6918,7 +6918,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -6932,7 +6932,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         Character: {
@@ -7019,7 +7019,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Audio: string;
         Character?: undefined;
@@ -7069,7 +7069,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7102,7 +7102,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -7115,7 +7115,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -7129,7 +7129,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7207,7 +7207,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         Character: {
@@ -7221,7 +7221,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Audio: string;
         Character?: undefined;
@@ -7230,7 +7230,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7305,7 +7305,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -7318,7 +7318,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -7348,7 +7348,7 @@ declare var PlatformDialogData: ({
             Reply: string;
             Audio: string;
             AudioStyle: string;
-            Script: () => void;
+            Script(): void;
             Goto?: undefined;
         } | {
             Text: string;
@@ -7378,7 +7378,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7397,7 +7397,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;
@@ -7410,7 +7410,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -7425,7 +7425,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Character: {
             Name: string;
@@ -7502,7 +7502,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7517,7 +7517,7 @@ declare var PlatformDialogData: ({
         Background?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -7592,7 +7592,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -7606,7 +7606,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -7620,7 +7620,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7698,7 +7698,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7707,7 +7707,7 @@ declare var PlatformDialogData: ({
         Answer?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7804,7 +7804,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Prerequisite?: undefined;
         Text?: undefined;
@@ -7817,7 +7817,7 @@ declare var PlatformDialogData: ({
     Name: string;
     Music: string;
     Dialog: ({
-        Entry: () => void;
+        Entry(): void;
         Character: {
             Name: string;
             Status: string;
@@ -7890,7 +7890,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7916,7 +7916,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Entry: () => void;
+        Entry(): void;
         Text: string;
         Audio: string;
         AudioStyle: string;
@@ -7981,7 +7981,7 @@ declare var PlatformDialogData: ({
         Prerequisite?: undefined;
         ID?: undefined;
     } | {
-        Prerequisite: () => boolean;
+        Prerequisite(): boolean;
         Text: string;
         Audio: string;
         Entry?: undefined;
@@ -7991,7 +7991,7 @@ declare var PlatformDialogData: ({
         ID?: undefined;
     } | {
         ID: string;
-        Entry: () => void;
+        Entry(): void;
         Character?: undefined;
         Text?: undefined;
         Audio?: undefined;

--- a/bc/Screens/Room/Shop2/Shop2.d.ts
+++ b/bc/Screens/Room/Shop2/Shop2.d.ts
@@ -146,17 +146,68 @@ declare namespace Shop2Consts {
     let Remotes: Set<string>;
 }
 declare namespace Shop2 {
+    /**
+     * Populate {@link Shop2Consts.BuyGroups} with buy groups.
+     * @private
+     */
     function _PopulateBuyGroups(): void;
+    /**
+     * Populate {@link Shop2InitVars.GroupDescriptions} with group descriptions and all corresponding group names
+     * @param {readonly ShopItem[]} assets
+     * @private
+     */
     function _PopulateGroupDescriptions(assets: readonly ShopItem[]): void;
+    /**
+     * Populate {@link Shop2Consts.Keys} and {@link Shop2Consts.Remote} with the name of all asset keys and remotes.
+     * @private
+     */
     function _PopulateKeysAndRemotes(): void;
+    /**
+     * Draw function for a single item in the shop
+     * @param {number} x
+     * @param {number} y
+     * @param {number} w
+     * @param {number} h
+     * @param {number} assetIndex - The assets index within {@link Shop2Vars.CurrentAssets}
+     * @satisfies {ShopScreenFunctions["Draw"]}
+     * @private
+     */
     function _AssetElementDraw(x: number, y: number, w: number, h: number, assetIndex: number): void;
+    /**
+     * Click function for a single item in the shop
+     * @param {MouseEvent | TouchEvent} event
+     * @param {number} assetIndex - The assets index within {@link Shop2Vars.CurrentAssets}
+     * @satisfies {ShopScreenFunctions["Click"]}
+     * @private
+     */
     function _AssetElementClick(event: MouseEvent | TouchEvent, assetIndex: number): void;
+    /**
+     * Construct screen functions for the <=12 items displayed in the shop.
+     * @returns {Record<string, ShopScreenFunctions>}
+     */
     function _GenerateAssetElements(): Record<string, ShopScreenFunctions>;
+    /**
+     * Filter the buy, sell and preview items in {@link Shop2Vars} based on the {@link Shop2Vars.Filters} settings,
+     * clipping the current {@link Shop2Vars.Page} if required.
+     * @param {boolean} clearDatalist - Whether the search bars datalist should be cleared (and thus be recomputed on a focus event)
+     */
     function ApplyItemFilters(clearDatalist?: boolean): void;
+    /** Click handler for the group-selection checkboxes */
     function _SetCheckboxFilters(): void;
+    /**
+     * Update the state of all pose-buttons, disabling or selecting them if so required.
+     */
     function _UpdatePoseButtons(): void;
+    /**
+     * @param {string} id
+     */
     function _ClickDropdown(id: string): void;
-    let DrawPriceRibbon: (label: string, x: number, y: number, w: number, color?: string) => void;
+    function DrawPriceRibbon(label: string, x: number, y: number, w: number, color?: string): void;
+    /**
+     * Convert the passed asset list into a list consisting of shop items
+     * @param {readonly Asset[]} assets - The assets in question
+     * @returns {ShopItem[]} - The shop items constructed from the passed assets
+     */
     function ParseAssets(assets: readonly Asset[]): ShopItem[];
     let Elements: Record<string, ShopScreenFunctions>;
     /**

--- a/bc/Scripts/Asset.d.ts
+++ b/bc/Scripts/Asset.d.ts
@@ -272,11 +272,28 @@ declare namespace PoseType {
     let DEFAULT: "";
 }
 declare namespace AssetResolveCopyConfig {
+    /**
+     * Take an (ordered) list of `CopyConfig`-referenced configs and group them all together in a `BuyGroup`.
+     * The buygroup's name will either be extracted from the configs if present, or alternatively use the `Name` of the top-most config.
+     * @param {readonly { BuyGroup?: string, Value?: number, Name?: string }[]} configList
+     */
     function _AssignBuyGroup(configList: readonly {
         BuyGroup?: string;
         Value?: number;
         Name?: string;
     }[]): void;
+    /**
+     * Merge the passed config with all it's to-be copied super configs (per its `CopyConfig` settings)
+     * @template {{ CopyConfig?: { GroupName?: AssetGroupName, AssetName: string }, BuyGroup?: string, Value?: number, Name?: string }} T
+     * @param {T} config - The (extended) asset config
+     * @param {string} assetName - The name of the corresponding asset
+     * @param {AssetGroupName} groupName - The name of the corresponding asset group
+     * @param {Partial<Record<AssetGroupName, Record<string, T>>>} configRecord - A (nested) record containing the configs of all assets
+     * @param {string} configType - The name of the config type. Used for error reporting
+     * @param {null | AssetCopyConfigValidator<T>} configValidator - An optional validator for comparing the config with its to-be copied counterpart(s)
+     * @param {boolean} setBuyGroup - Whether to automatically assign a buygroup to the config and, if required, all `CopyConfig`-referenced super configs
+     * @returns {null | T} - The original config merged with its to-be copied super configs. Returns `null` if an error is encountered.
+     */
     function _Resolve<T extends {
         CopyConfig?: {
             GroupName?: AssetGroupName;
@@ -286,8 +303,24 @@ declare namespace AssetResolveCopyConfig {
         Value?: number;
         Name?: string;
     }>(config: T, assetName: string, groupName: AssetGroupName, configRecord: Partial<Record<AssetGroupName, Record<string, T>>>, configType: string, configValidator?: null | AssetCopyConfigValidator<T>, setBuyGroup?: boolean): null | T;
-    let _ExtendedValidator: AssetCopyConfigValidator<AssetArchetypeConfig>;
+    function _ExtendedValidator(config: AssetArchetypeConfig, superConfig: AssetArchetypeConfig, key: string, superKey: string): boolean;
+    /**
+     * Construct the items asset config, merging via {@link AssetDefinition.CopyConfig} if required.
+     * @param {AssetDefinition} assetDef - The asset definition
+     * @param {AssetGroupName} groupName - The name of the asset group
+     * @param {Partial<Record<AssetGroupName, Record<string, AssetDefinition>>>} assetRecord - A record containg all asset definitions
+     * @returns {null | AssetDefinition} - The oiginally passed base item configuration.
+     * Returns `null` insstead if an error was encountered.
+     */
     function AssetDefinition(assetDef: AssetDefinition, groupName: AssetGroupName, assetRecord: Partial<Record<AssetGroupName, Record<string, AssetDefinition>>>): null | AssetDefinition;
+    /**
+     * Construct the items extended item config, merging via {@link AssetArchetypeConfig.CopyConfig} if required.
+     * @param {Asset} asset - The asset to configure
+     * @param {AssetArchetypeConfig} config - The extended item configuration of the base item
+     * @param {ExtendedItemMainConfig} extendedConfig - The extended item configuration object for the asset's family
+     * @returns {null | AssetArchetypeConfig} - The oiginally passed base item configuration.
+     * Returns `null` instead if an error was encountered.
+     */
     function ExtendedItemConfig(asset: Asset, config: AssetArchetypeConfig, extendedConfig: ExtendedItemMainConfig): null | AssetArchetypeConfig;
 }
 declare const AssetStringsPath: "Assets/Female3DCG/AssetStrings.csv";

--- a/bc/Scripts/Dialog.d.ts
+++ b/bc/Scripts/Dialog.d.ts
@@ -1009,12 +1009,17 @@ declare namespace DialogLeaveFocusItemHandlers {
 }
 declare namespace DialogEffectIcons {
     let Table: Partial<Record<InventoryIcon, readonly EffectName[]>>;
+    /**
+     * Return icons for each "interesting" effect on the item.
+     * @param {Item} item
+     * @returns {InventoryIcon[]} - A list of icon names.
+     */
     function GetIcons(item: Item): InventoryIcon[];
-    let GetEffectIcons: (effects: Iterable<EffectName>, prop?: CraftingPropertyType) => null | InventoryIcon[];
+    function GetEffectIcons(effects: Iterable<EffectName>, prop?: CraftingPropertyType): null | InventoryIcon[];
     function _GetGagIcon(effect: EffectName, prop?: CraftingPropertyType): null | InventoryIcon;
     function _GetBlindIcon(effect: EffectName, prop?: CraftingPropertyType): null | InventoryIcon;
     function _GetDeafIcon(effect: EffectName): undefined | InventoryIcon;
-    let _GagLevelToIcon: (level?: number) => null | InventoryIcon;
-    let _BlindLevelToIcon: (level?: number) => null | InventoryIcon;
+    function _GagLevelToIcon(level?: number): null | InventoryIcon;
+    function _BlindLevelToIcon(level?: number): null | InventoryIcon;
 }
 declare function DialogMouseWheel(Event: any): boolean;

--- a/bc/Scripts/ExtendedItem.d.ts
+++ b/bc/Scripts/ExtendedItem.d.ts
@@ -411,6 +411,19 @@ declare var ExtendedItemPermissionMode: boolean;
 declare var ExtendedItemSubscreen: string | null;
 declare function ExtendedItemGatherOptions(item: Item): ExtendedItemOptionUnion[];
 declare namespace ExtendedItemTighten {
+    /**
+     * Draw function for tightening/loosening.
+     * @param {ExtendedItemData<any>} data The extended item data
+     * @param {Item} item The item in question
+     * @param {RectTuple} buttonCoords A 4-tuple with the buttons coordinates
+     */
     function Draw({ asset }: ExtendedItemData<any>, item: Item, buttonCoords: RectTuple): void;
+    /**
+     * Click function for tightening/loosening.
+     * @param {ExtendedItemData<any>} data The extended item data
+     * @param {Item} item The item in question
+     * @param {RectTuple} buttonCoords A 4-tuple with the buttons coordinates
+     * @returns {boolean} Whether the button was clicked or not
+     */
     function Click({ asset }: ExtendedItemData<any>, item: Item, buttonCoords: RectTuple): boolean;
 }

--- a/bc/Scripts/Inventory.d.ts
+++ b/bc/Scripts/Inventory.d.ts
@@ -529,14 +529,46 @@ declare function InventoryShockExpression(C: Character): void;
 declare function InventoryExtractLockProperties(property: ItemProperties): ItemProperties;
 declare namespace InventoryPrerequisiteConflicts {
     let GagPriorities: Partial<Record<AssetGroupName, number>>;
+    /**
+     * @private
+     * @template {keyof PropertiesArray} T
+     * @param {T} fieldName
+     * @param {Character} C - The character on which we check for prerequisites
+     * @param {PropertiesArray[T]} blockingPrereqs - The prerequisites we check for on lower gags
+     * @param {Asset} asset - The new gag
+     * @param {Object} options
+     * @param {string} [options.errMessage] - The to-be returned message if the gag is blocked
+     * @param {boolean} [options.invert] - Whether the prerequisite check should be inverted (_i.e._ if "not any" instead of "any")
+     * @returns {string} - Returns the error message if the gag is blocked, or an empty string if not
+     */
     function _GagCheck<T extends keyof PropertiesArray>(fieldName: T, C: Character, blockingPrereqs: PropertiesArray[T], asset?: Asset, options?: {
         errMessage?: string;
         invert?: boolean;
     }): string;
+    /**
+     * Check if there are any lower gags with prerequisites that block the new gag from being applied
+     * @param {Character} C - The character on which we check for prerequisites
+     * @param {readonly AssetPrerequisite[]} blockingPrereqs - The prerequisites we check for on lower gags
+     * @param {Asset} asset - The new gag
+     * @param {Object} options
+     * @param {string} [options.errMessage] - The to-be returned message if the gag is blocked
+     * @param {boolean} [options.invert] - Whether the prerequisite check should be inverted (_i.e._ if "not any" instead of "any")
+     * @returns {string} - Returns the error message if the gag is blocked, or an empty string if not
+     */
     function GagPrerequisite(C: Character, blockingPrereqs: readonly AssetPrerequisite[], asset?: Asset, options?: {
         errMessage?: string;
         invert?: boolean;
     }): string;
+    /**
+     * Check if there are any lower gags with effects that block the new gag from being applied
+     * @param {Character} C - The character on which we check for prerequisites
+     * @param {readonly EffectName[]} blockingEffects - The prerequisites we check for on lower gags
+     * @param {Asset} asset - The new gag
+     * @param {Object} options
+     * @param {string} [options.errMessage] - The to-be returned message if the gag is blocked
+     * @param {boolean} [options.invert] - Whether the prerequisite check should be inverted (_i.e._ if "not any" instead of "any")
+     * @returns {string} - Returns the error message if the gag is blocked, or an empty string if not
+     */
     function GagEffect(C: Character, blockingEffects: readonly EffectName[], asset?: Asset, options?: {
         errMessage?: string;
         invert?: boolean;

--- a/bc/Scripts/NoArch.d.ts
+++ b/bc/Scripts/NoArch.d.ts
@@ -28,7 +28,22 @@ declare function NoArchCreateNoArchItemData(asset: Asset, { DialogPrefix, ChatTa
  */
 declare const NoArchItemDataLookup: Record<string, NoArchItemData>;
 declare namespace NoArch {
+    /**
+     * @param {ExtendedItemData<any>} data
+     * @param {Character} C — The character that has the item equiped
+     * @param {Item} item — The item in question
+     * @param {boolean} push - Whether to push to changes to the server
+     * @param {boolean} refresh - Whether to refresh the character. This should generally be `true`, with custom script hooks being a potential exception.
+     * @returns {boolean} Whether properties were updated or not
+     */
     function Init(data: ExtendedItemData<any>, C: Character, item: Item, push?: boolean, refresh?: boolean): boolean;
+    /**
+     * @param {ExtendedItemData<any>} data
+     */
     function Draw(data: ExtendedItemData<any>): void;
+    /**
+     * @param {ExtendedItemData<any>} data
+     * @returns {boolean} Whether a button was clicked or not
+     */
     function Click(data: ExtendedItemData<any>): boolean;
 }

--- a/bc/Scripts/Pose.d.ts
+++ b/bc/Scripts/Pose.d.ts
@@ -65,7 +65,20 @@ declare const PoseAllKneeling: readonly ("Kneel" | "KneelingSpread")[];
  */
 declare const PoseAllStanding: readonly ("BaseLower" | "LegsClosed" | "LegsOpen" | "Spread")[];
 declare namespace PoseToMapping {
+    /**
+     * Unflatten a pose name array, converting it into a record mapping pose categories to aforementioned pose names
+     * @param {readonly AssetPoseName[]} poses - The to-be unflattened pose array
+     * @param {null | string} warningPrefix - A prefix to-be prepended to any warning messages
+     * @returns {Partial<Record<AssetPoseCategory, AssetPoseName[]>>}
+     */
     function Array(poses: readonly AssetPoseName[], warningPrefix?: null | string): Partial<Record<AssetPoseCategory, AssetPoseName[]>>;
+    /**
+     * Unflatten a pose name array, converting it into a record mapping pose categories to a single pose.
+     * A warning will be logged if multiple poses within the same category are present.
+     * @param {readonly AssetPoseName[]} poses - The to-be unflattened pose array
+     * @param {null | string} warningPrefix - A prefix to-be prepended to any warning messages
+     * @returns {Partial<Record<AssetPoseCategory, AssetPoseName>>}
+     */
     function Scalar(poses: readonly AssetPoseName[], warningPrefix?: null | string): Partial<Record<AssetPoseCategory, AssetPoseName>>;
 }
 declare namespace PoseChangeStatus {

--- a/bc/Scripts/TextItem.d.ts
+++ b/bc/Scripts/TextItem.d.ts
@@ -45,10 +45,40 @@ declare function TextItemPropertyRevert({ textNames }: TextItemData, item: Item)
  */
 declare const TextItemDataLookup: Record<string, TextItemData>;
 declare namespace TextItem {
+    /**
+     * Init function for items with text input fields.
+     * @param {TextItemData} data
+     * @param {Character} C — The character that has the item equiped
+     * @param {Item} item — The item in question
+     * @param {boolean} push - Whether to push to changes to the server
+     * @param {boolean} refresh - Whether to refresh the character. This should generally be `true`, with custom script hooks being a potential exception.
+     * @returns {boolean} Whether properties were updated or not
+     */
     function Init({ asset, font, baselineProperty, maxLength }: TextItemData, C: Character, item: Item, push?: boolean, refresh?: boolean): boolean;
+    /**
+     * Load function for items with text input fields.
+     * @param {TextItemData} data
+     */
     function Load(data: TextItemData): void;
+    /**
+     * Draw handler for extended item screens with text input fields.
+     * @param {TextItemData} data - The items extended item data
+     */
     function Draw(data: TextItemData): void;
+    /**
+     * Exit function for items with text input fields.
+     * @param {TextItemData} data - The items extended item data
+     * @param {boolean} publishAction - Whether
+     */
     function Exit(data: TextItemData, publishAction?: boolean): void;
+    /**
+     * PublishAction function for items with text input fields.
+     * @param {TextItemData} data - The items extended item data
+     * @param {Character} C - The character in question
+     * @param {Item} item - The item in question
+     * @param {TextItemOption} newOption
+     * @param {TextItemOption} previousOption
+     */
     function PublishAction(data: TextItemData, C: Character, item: Item, newOption: TextItemOption, previousOption: TextItemOption): void;
 }
 /**

--- a/bc/Scripts/VibratorMode.d.ts
+++ b/bc/Scripts/VibratorMode.d.ts
@@ -187,9 +187,46 @@ declare const VibratorModeDataLookup: Record<string, VibratingItemData>;
  */
 declare const VibratorModeUpdate: Partial<Record<VibratorMode, (data: VibratingItemData, C: Character, item: Item, persistentData: VibratorModePersistentData) => void>>;
 declare namespace VibratorModeStateUpdate {
+    /**
+     * Vibrator update function for vibrator state machine modes in the Default state
+     * @param {Character} C - The character that the item is equipped on
+     * @param {number} arousal - The current arousal of the character
+     * @param {number} timeSinceLastChange - The time in milliseconds since the vibrator intensity was last changed
+     * @param {VibratorIntensity} oldIntensity - The current intensity of the vibrating item
+     * @param {readonly VibratorModeState[]} transitionsFromDefault - The possible vibrator states that may be transitioned to from
+     * the default state
+     * @returns {StateAndIntensity} - The updated state and intensity of the vibrator
+     */
     function Default(C: Character, arousal: number, timeSinceLastChange: number, oldIntensity: VibratorIntensity, transitionsFromDefault: readonly VibratorModeState[]): StateAndIntensity;
+    /**
+     * Vibrator update function for vibrator state machine modes in the Deny state
+     * @param {Character} C - The character that the item is equipped on
+     * @param {number} arousal - The current arousal of the character
+     * @param {number} timeSinceLastChange - The time in milliseconds since the vibrator intensity was last changed
+     * @param {VibratorIntensity} oldIntensity - The current intensity of the vibrating item
+     * the default state
+     * @returns {StateAndIntensity} - The updated state and intensity of the vibrator
+     */
     function Deny(C: Character, arousal: number, timeSinceLastChange: number, oldIntensity: VibratorIntensity): StateAndIntensity;
+    /**
+     * Vibrator update function for vibrator state machine modes in the Orgasm state
+     * @param {Character} C - The character that the item is equipped on
+     * @param {number} arousal - The current arousal of the character
+     * @param {number} timeSinceLastChange - The time in milliseconds since the vibrator intensity was last changed
+     * @param {VibratorIntensity} oldIntensity - The current intensity of the vibrating item
+     * the default state
+     * @returns {StateAndIntensity} - The updated state and intensity of the vibrator
+     */
     function Orgasm(C: Character, arousal: number, timeSinceLastChange: number, oldIntensity: VibratorIntensity): StateAndIntensity;
+    /**
+     * Vibrator update function for vibrator state machine modes in the Rest state
+     * @param {Character} C - The character that the item is equipped on
+     * @param {number} arousal - The current arousal of the character
+     * @param {number} timeSinceLastChange - The time in milliseconds since the vibrator intensity was last changed
+     * @param {VibratorIntensity} oldIntensity - The current intensity of the vibrating item
+     * the default state
+     * @returns {StateAndIntensity} - The updated state and intensity of the vibrator
+     */
     function Rest(C: Character, arousal: number, timeSinceLastChange: number, oldIntensity: VibratorIntensity): StateAndIntensity;
 }
 type VibratorModePersistentData = {

--- a/bc_data/package.json
+++ b/bc_data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-data",
-  "version": "110.0.0",
+  "version": "110.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"

--- a/namespace_function_sanitize.py
+++ b/namespace_function_sanitize.py
@@ -1,0 +1,51 @@
+"""
+Sanitize any nested functions, turning the likes of `foo: function foo()` and `foo: function()` into `foo()`.
+
+Used as a crutch for getting typescript to include docstrings in namespace-embedded functions
+(xref https://github.com/bananarama92/BC-stubs/issues/18).
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import os
+import re
+
+PATTERN = re.compile(r"([a-zA-Z0-9_]+)\: function( )?([a-zA-Z0-9_]+)?( )?\(")
+
+
+def _replacer(match: re.Match[str]) -> str:
+    groups = match.groups()
+    if (groups[2] is None or groups[2] == groups[0]):
+        return f"{match.groups()[0]}("
+    else:
+        return ""
+
+
+def main(root: str | os.PathLike[str]) -> None:
+    file_iter = itertools.chain.from_iterable(
+        [os.path.join(root, i) for i in files if i.endswith(".js")]
+        for (root, _, files) in os.walk(root)
+    )
+
+    for path in file_iter:
+        with open(path, "r", encoding="utf8") as f_inp:
+            text_inp = f_inp.read()
+
+        text_out = PATTERN.sub(_replacer, text_inp)
+        if text_inp != text_out:
+            with open(path, "w", encoding="utf8") as f_out:
+                f_out.write(text_out)
+
+
+if __name__ == "__main__":
+    description = None if __doc__ is None else __doc__.splitlines()[1]
+    parser = argparse.ArgumentParser(
+        usage="python ./namespace_function_sanitize.py ./BondageClub",
+        description=description,
+    )
+    parser.add_argument("path", help="Path to the BC root directory")
+    args = parser.parse_args()
+    main(args.path)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-stubs",
-  "version": "110.0.0",
+  "version": "110.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"


### PR DESCRIPTION
Closes https://github.com/bananarama92/BC-stubs/issues/18

Work around the relevant typescript bug by converting all namespace-embedded functions (`Foo: function Foo()` and `Foo: function()`) into proper methods (`Foo()`).

BC Version: R110
Repo: https://gitgud.io/bananarama92/Bondage-College.git
Branch: `typtyptyp`
Commit: `ab64cd4c83e6e0a6c90e5945c0a253eb105e68db`