### PR TITLE
BUG: Make the namespace_function_sanitize.py regex more lenient

### DIFF
--- a/bc/Screens/Room/PlatformDialog/PlatformDialog.d.ts
+++ b/bc/Screens/Room/PlatformDialog/PlatformDialog.d.ts
@@ -256,7 +256,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -356,7 +356,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -467,7 +467,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -732,8 +732,8 @@ declare var PlatformDialogData: ({
         TextScript?: undefined;
         AudioScript?: undefined;
     } | {
-        TextScript: () => "Can I have my orgasm Lady Olivia?" | "It's time for the climax.";
-        AudioScript: () => "O221" | "O222";
+        TextScript(): "Can I have my orgasm Lady Olivia?" | "It's time for the climax.";
+        AudioScript(): "O221" | "O222";
         Background?: undefined;
         Character?: undefined;
         Text?: undefined;
@@ -742,8 +742,8 @@ declare var PlatformDialogData: ({
         ID?: undefined;
         Entry?: undefined;
     } | {
-        TextScript: () => "Yes, you can have your orgasm my maid." | "(She smiles and watches you carefully.)";
-        AudioScript: () => string;
+        TextScript(): "Yes, you can have your orgasm my maid." | "(She smiles and watches you carefully.)";
+        AudioScript(): string;
         Character: {
             Name: string;
             Status: string;
@@ -817,7 +817,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -890,7 +890,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -921,7 +921,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -1113,7 +1113,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -1245,7 +1245,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -1359,7 +1359,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -1684,7 +1684,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -2039,7 +2039,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Text: string;
         Background: string;
@@ -2101,7 +2101,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Text: string;
         Audio: string;
@@ -2253,7 +2253,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Text: string;
         Audio: string;
@@ -2773,7 +2773,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -2952,7 +2952,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Entry(): void;
@@ -3092,7 +3092,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Entry(): void;
@@ -3277,7 +3277,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Entry(): void;
@@ -3423,7 +3423,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -3553,7 +3553,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: ({
@@ -3814,7 +3814,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Text: string;
         Background: string;
@@ -4232,7 +4232,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Text: string;
         Character?: undefined;
@@ -5195,7 +5195,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Entry(): void;
@@ -5325,7 +5325,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Entry(): void;
@@ -5483,7 +5483,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Entry(): void;
@@ -5652,7 +5652,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {
@@ -5721,7 +5721,7 @@ declare var PlatformDialogData: ({
 } | {
     Name: string;
     Music: string;
-    Exit: () => void;
+    Exit(): void;
     Dialog: ({
         Background: string;
         Character: {

--- a/bc/Scripts/Asset.d.ts
+++ b/bc/Scripts/Asset.d.ts
@@ -271,6 +271,7 @@ declare namespace PoseType {
     let HIDE: "Hide";
     let DEFAULT: "";
 }
+declare const layers: any[];
 declare namespace AssetResolveCopyConfig {
     /**
      * Take an (ordered) list of `CopyConfig`-referenced configs and group them all together in a `BuyGroup`.

--- a/bc/Scripts/Element.d.ts
+++ b/bc/Scripts/Element.d.ts
@@ -415,10 +415,10 @@ declare namespace ElementMenu {
      * @param {HTMLElement} menuitem - The to-be prepended menuitem
      */
     export function AppendButton(div: HTMLDivElement, menuitem: HTMLElement): void;
-    export let div: any;
-    export { menuitem };
-}
-declare var _: any;
-declare namespace menuitem {
-    let role: string;
+    /**
+     * Prepend a menuitem to the passed menubar
+     * @param {HTMLDivElement} div - The menubar
+     * @param {HTMLElement} menuitem - The to-be prepended menuitem
+     */
+    export function PrependItem(div: HTMLDivElement, menuitem: HTMLElement): void;
 }

--- a/bc_data/package.json
+++ b/bc_data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-data",
-  "version": "110.0.1",
+  "version": "110.0.2",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"

--- a/namespace_function_sanitize.py
+++ b/namespace_function_sanitize.py
@@ -13,15 +13,11 @@ import itertools
 import os
 import re
 
-PATTERN = re.compile(r"([a-zA-Z0-9_]+)\: function( )?([a-zA-Z0-9_]+)?( )?\(")
+PATTERN = re.compile(r"([a-zA-Z0-9_]+)(\s+)?\:(\s+)?function(\s+)?([a-zA-Z0-9_]+)?(\s+)?\(")
 
 
 def _replacer(match: re.Match[str]) -> str:
-    groups = match.groups()
-    if (groups[2] is None or groups[2] == groups[0]):
-        return f"{match.groups()[0]}("
-    else:
-        return ""
+    return f"{match.groups()[0]}("
 
 
 def main(root: str | os.PathLike[str]) -> None:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-stubs",
-  "version": "110.0.1",
+  "version": "110.0.2",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"


### PR DESCRIPTION
CC @KittenApps

Fixes an issue introduced in https://github.com/bananarama92/BC-stubs/pull/48 wherein string-substitution would fail for `Foo: function Bar()`-type functions (with `Foo != Bar`), resulting in the removal and/or breakage of the relevant symbol in the final declaration file.

BC Version: R110
Repo: https://gitgud.io/bananarama92/Bondage-College.git
Branch: `typtyptyp`
Commit: `ab64cd4c83e6e0a6c90e5945c0a253eb105e68db`