### PR TITLE
REL: Bump version to v115.0.1

### DIFF
--- a/bc/Scripts/Dialog.d.ts
+++ b/bc/Scripts/Dialog.d.ts
@@ -1523,6 +1523,7 @@ declare class _DialogExpressionMenu<ModeType extends DialogSelfMenuName> extends
      */
     get facialExpressions(): Readonly<Partial<Record<ExpressionGroupName, readonly (null | ExpressionName)[]>>>;
     get focusGroup(): AssetAppearanceGroup;
+    /** @satisfies {Record<string, (this: HTMLElement, ev: Event) => any>} */
     eventListeners: {
         _expressionRadioGroupClick(this: HTMLButtonElement, ev: MouseEvent): void;
         _ClickMenuButton(this: HTMLButtonElement, ev: MouseEvent): void;
@@ -1532,6 +1533,29 @@ declare class _DialogExpressionMenu<ModeType extends DialogSelfMenuName> extends
         _ClickPaginatePrev(this: HTMLButtonElement, ev: MouseEvent): void;
         _ClickPaginateNext(this: HTMLButtonElement, ev: MouseEvent): void;
         _WheelGrid(this: HTMLDivElement, event: WheelEvent): void;
+    };
+    /** @satisfies {Record<string, DialogMenu.MenuButtonData<{ C: PlayerCharacter }>>} */
+    menubarEventListeners: {
+        /** @type {DialogMenu.MenuButtonData<{ C: PlayerCharacter }>} */
+        color: DialogMenu.MenuButtonData<{
+            C: PlayerCharacter;
+        }>;
+        /** @type {DialogMenu.MenuButtonData<{ C: PlayerCharacter }>} */
+        blindness: DialogMenu.MenuButtonData<{
+            C: PlayerCharacter;
+        }>;
+        /** @type {DialogMenu.MenuButtonData<{ C: PlayerCharacter }>} */
+        blink: DialogMenu.MenuButtonData<{
+            C: PlayerCharacter;
+        }>;
+        /** @type {DialogMenu.MenuButtonData<{ C: PlayerCharacter }>} */
+        clear: DialogMenu.MenuButtonData<{
+            C: PlayerCharacter;
+        }>;
+        /** @type {DialogMenu.MenuButtonData<{ C: PlayerCharacter }>} */
+        next: DialogMenu.MenuButtonData<{
+            C: PlayerCharacter;
+        }>;
     };
     /**
      * A {@link DialogMenu.Reload} helper function for reloading {@link DialogMenu.ids.status} elements.
@@ -1561,6 +1585,7 @@ declare class _DialogExpressionMenu<ModeType extends DialogSelfMenuName> extends
      */
     _ReloadIcon(root: HTMLElement, icon: HTMLElement, properties: DialogMenu.InitProperties, options: Pick<DialogMenu.ReloadOptions, never>): void;
 }
+declare const bob: _DialogExpressionMenu<"Expression">;
 /**
  * @template {DialogSelfMenuName} ModeType
  * @extends {_DialogSelfMenu<ModeType, Pose>}

--- a/bc_data/package.json
+++ b/bc_data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-data",
-  "version": "115.0.0",
+  "version": "115.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-stubs",
-  "version": "115.0.0",
+  "version": "115.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"


### PR DESCRIPTION
* Use `satisfies` over `type` when annotation `DialogMenu` menubar event listeners, as the latter can cause TS to trip up w.r.t. further additions

BC Version: R115
Repo: https://gitgud.io/bananarama92/Bondage-College.git
Branch: `typtyptyp`
Commit: `cb16ba1d6cb43da465b86c2183821af24edc8ff3`