### PR TITLE
MAINT: Unconditionally strip out all JSDoc `@private`/`@protected` tags

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -91,16 +91,16 @@ jobs:
           # (xref https://github.com/bananarama92/BC-stubs/issues/18)
           python ../../namespace_function_sanitize.py .
 
+          # Get rid of JSDoc @private/@protected comments as TS lacks support for those in anonymous classes because... reasons?
+          # (xref https://github.com/microsoft/TypeScript/issues/30355)
+          python ../../remove_private_protected.py .
+
           set +e
           npx -p typescript tsc
           set -e
 
           rm -rf ../../bc
           mv dist ../../bc
-
-      - name: List NPM packages
-        run: |
-          npm list
 
       - name: Update BC-data
         run: |

--- a/bc/NativeDeclarations/Typedef.d.ts
+++ b/bc/NativeDeclarations/Typedef.d.ts
@@ -1819,7 +1819,7 @@ interface Character {
 	InventoryData?: string;
 	Appearance: Item[];
 	/**
-	 * @private
+	 * private
 	 * @see {@link Character.Stage}
 	 */
 	_Stage: string;
@@ -1827,7 +1827,7 @@ interface Character {
 	get Stage(): string;
 	set Stage(value: string);
 	/**
-	 * @private
+	 * private
 	 * @see {@link Character.CurrentDialog}
 	 */
 	_CurrentDialog: string;

--- a/bc/Screens/Online/ChatRoom/ChatRoom.d.ts
+++ b/bc/Screens/Online/ChatRoom/ChatRoom.d.ts
@@ -1723,7 +1723,7 @@ declare namespace ChatRoomSep {
     let _ClickScrollUp: (this: HTMLButtonElement, event: MouseEvent | TouchEvent) => Promise<void>;
     /**
      * Return a {@link HTMLElement.InnerHTML} representation of the passed button's room name
-     * @private
+     * private
      * @param {HTMLButtonElement} button
      * @returns {(string | HTMLElement)[]}
      */

--- a/bc/Screens/Online/ChatRoom/ChatRoomMapView.d.ts
+++ b/bc/Screens/Online/ChatRoom/ChatRoomMapView.d.ts
@@ -1,0 +1,651 @@
+/**
+ * Returns TRUE if the player is an admin and activated her super powers on the map
+ * @returns {boolean} - TRUE if super powers are active
+ */
+declare function ChatRoomMapViewHasSuperPowers(): boolean;
+/**
+ * When the screen loses focus, we clear the keys pressed because we don't want movement to get stuck
+ */
+declare function ChatRoomMapViewBlur(): void;
+/**
+ * Initializes the map to its default blank state
+ * @param {ChatRoomMapType} mode
+ * @returns {ServerChatRoomMapData}
+ */
+declare function ChatRoomMapViewInitialize(mode: ChatRoomMapType): ServerChatRoomMapData;
+/**
+ * Initializes the player map data to its default blank state
+ * @param {Character} C - The character to be initialized
+ * @returns {ChatRoomMapData}
+ */
+declare function ChatRoomMapViewInitializeCharacter(C: Character): ChatRoomMapData;
+/**
+ * Validate the passed chat room map positions.
+ * @param {unknown} position
+ * @returns {ChatRoomMapPos}
+ */
+declare function ChatRoomMapViewValidatePosition(position: unknown): ChatRoomMapPos;
+/**
+ * Checks if the coordinates are out of bounds relative to the map
+ * @param {ChatRoomMapPos} position
+ */
+declare function ChatRoomMapViewIsOutOfBounds(position: ChatRoomMapPos): boolean;
+/**
+ * Performs cleanup when leaving the chat room map
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewLeave(): void;
+/**
+ * Activates the chat room map
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewActivate(): void;
+/**
+ * Deactivates the chat room map
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewDeactivate(): void;
+/**
+ * Indicates if the chat room map view is active or not
+ * @returns {boolean} - TRUE if the chat room character view is active, false if not
+ */
+declare function ChatRoomMapViewIsActive(): boolean;
+declare function ChatRoomMapViewRun(time: number): void;
+/**
+ * Returns TRUE if the player can leave from the map
+ * @returns {boolean} - True if the player can leave
+ */
+declare function ChatRoomMapViewCanLeave(): boolean;
+/**
+ * Take a screenshot of the current section of the map
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewScreenshot(): void;
+/**
+ * Returns TRUE if the player can enter in whisper mode on the current view with the currently focused character
+ * @param {Character} C - The character to evaluate
+ * @returns {boolean} - TRUE is whipser can be started
+ */
+declare function ChatRoomMapViewCanStartWhisper(C: Character): boolean;
+/**
+ * Handles the reception of the room properties from the server.
+ * @param {ServerChatRoomSyncMessage} data - Room object containing the updated chatroom properties.
+ * @returns {void} - Nothing.
+ */
+declare function ChatRoomMapViewSyncRoomProperties(data: ServerChatRoomSyncMessage): void;
+/**
+ * Gets a index number for the tile and obejct lists and returns the corrosponting coordinates in X and Y
+ * @param {number} index - Index number for the tile and object lists
+ * @returns {{x: number, y: number}} - Object containing the resulting x and y coordinates.
+ */
+declare function ChatRoomMapViewIndexToCoordinates(index: number): {
+    x: number;
+    y: number;
+};
+/**
+ * Gets coordinates in X and Y and returns the corrosponding index number for the tile and object list
+ * @param {number} x - X-coordinate to be translated
+ * @param {number} y - Y-coordinate to be translated
+ * @returns {number} - Index number for the tile and object lists
+ */
+declare function ChatRoomMapViewCoordinatesToIndex(x: number, y: number): number;
+/**
+ * Calculates the visibility mask and audibility mask for the map
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewCalculatePerceptionMasks(): void;
+/**
+ * Returns the sight range for the current player, based on the blindness level
+ * @returns {number} - The number of visible tiles
+ */
+declare function ChatRoomMapViewGetSightRange(): number;
+/**
+ * Returns the hearing range for the current player, based on the deafness level
+ * @returns {number} - The number of tiles
+ */
+declare function ChatRoomMapViewGetHearingRange(): number;
+/**
+ * Returns TRUE if the player can see a character at her sight range
+ * @param {Character} C - The character to evaluate
+ * @returns {boolean} - TRUE if visible
+ */
+declare function ChatRoomMapViewCharacterIsVisible(C: Character): boolean;
+/**
+ * Returns TRUE if the player can see hear a character at her hearing range
+ * @param {Character} C - The character to evaluate
+ * @returns {boolean} - TRUE if hearable
+ */
+declare function ChatRoomMapViewCharacterIsHearable(C: Character): boolean;
+/**
+ * Returns TRUE if the player is on whisper range to another character (1 tile)
+ * @param {Character} C - The character to evaluate
+ * @returns {boolean} - TRUE if on whisper range
+ */
+declare function ChatRoomMapViewCharacterOnWhisperRange(C: Character): boolean;
+/**
+ * Returns TRUE if the player is within interaction range of another character
+ * @param {Character} C - The character to evaluate
+ * @returns {boolean} - TRUE if on interaction range
+ */
+declare function ChatRoomMapViewCharacterOnInteractionRange(C: Character): boolean;
+/**
+ * Sets the correct wall tile based on it's surrounding (North-West, North-Center, etc.)
+ * @param {boolean} CW - If Center West is a wall
+ * @param {boolean} CE - If Center East is a wall
+ * @param {boolean} SW - If South West is a wall
+ * @param {boolean} SC - If South Center is a wall
+ * @param {boolean} SE - If South East is a wall
+ * @returns {number} - a number linked on the image to use
+ */
+declare function ChatRoomMapViewFindWallEffectTile(CW: boolean, CE: boolean, SW: boolean, SC: boolean, SE: boolean): number;
+/**
+ * Returns TRUE if the X and Y coordinates is a wall tile, if out of bound we also return TRUE
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @returns {boolean} - TRUE if it's a wall
+ */
+declare function ChatRoomMapViewIsWall(X: number, Y: number): boolean;
+/**
+ * Checks for connectivity in 4 directions based on a provided validation function
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @param {function(number, number): boolean} Condition - Function that returns true if the position is connected
+ * @returns {{ North: boolean, South: boolean, East: boolean, West: boolean }} - The connectivity status
+ */
+declare function ChatRoomMapViewGetConnectivityDirections(X: number, Y: number, Condition: (arg0: number, arg1: number) => boolean): {
+    North: boolean;
+    South: boolean;
+    East: boolean;
+    West: boolean;
+};
+/**
+ * Returns the object located at a X and Y position on the map, or NULL if nothing
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @returns {ChatRoomMapTile | null} - The object at the position
+ */
+declare function ChatRoomMapViewGetTileAtPos(X: number, Y: number): ChatRoomMapTile | null;
+/**
+ * Returns the object located at a X and Y position on the map, or NULL if nothing
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @returns {ChatRoomMapObject | null} - The object at the position
+ */
+declare function ChatRoomMapViewGetObjectAtPos(X: number, Y: number): ChatRoomMapObject | null;
+/**
+ * Returns TRUE if a given position cannot be entered
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @returns {boolean} - TRUE if the position is blocked
+ */
+declare function ChatRoomMapViewPositionIsBlocked(X: number, Y: number): boolean;
+/**
+ * Returns TRUE if the fog of war feature is currently activated on the map
+ * @returns {boolean} - TRUE if fog of war is active
+ */
+declare function ChatRoomMapFogIsActive(): boolean;
+/**
+ * Returns TRUE if a tile is fully hidden from hide
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @returns {boolean} - TRUE if the tile is hidden
+ */
+declare function ChatRoomMapViewTileIsHidden(X: number, Y: number): boolean;
+/**
+ * Apply a wall "3D" effect on the curent map
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @param {number} ScreenX - The X position on the screen
+ * @param {number} ScreenY - The Y position on the screen
+ * @param {number} TileWidth - The visible width of a tile
+ * @param {number} TileHeight - The visible height of a tile
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewWallEffect(X: number, Y: number, ScreenX: number, ScreenY: number, TileWidth: number, TileHeight: number): void;
+/**
+ * Apply a wall "3D" effect on the curent map
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @returns {number} - The effect number
+ */
+declare function ChatRoomMapViewFloorWallEffect(X: number, Y: number): number;
+/**
+ * Manages collisions, moves the player if she's on a tile that cannot be entered
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewCollision(): void;
+/**
+ * Find the first {@link ChatRoomCharacter} members at the specified X & Y position
+ * @param {number} X - The X position on the screen
+ * @param {number} Y - The Y position on the screen
+ * @returns {null | Character} A character at the specified X & Y position or, if none can be found, `null`
+ */
+declare function ChatRoomMapViewGetCharacterAtPos(X: number, Y: number): null | Character;
+/**
+ * Returns a object that contains the entry flag's position with x and y parameters or null if no entry flag is set
+ * @returns {ChatRoomMapPos|null}
+ */
+declare function ChatRoomMapViewGetEntryFlagPosition(): ChatRoomMapPos | null;
+/**
+ * Draw the map grid and character on screen
+ * @param {number} Left - The X position on the screen
+ * @param {number} Top - The Y position on the screen
+ * @param {number} Width - The width size of the drawn map
+ * @param {number} Height - The height size of the drawn map
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewDrawGrid(Left: number, Top: number, Width: number, Height: number): void;
+/**
+ * Sets the next update flag for the room if it's not already set, the delay is 5 seconds
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewUpdateFlag(): void;
+/**
+ * Sets the next update flags for the player if it's not already set, the delay is 1 seconds for live data and 10 seconds for last map data
+ * @param {number} UpdateTimeOffset - A offset for the update time. This can be positive to increase the update time or negative to reduce it.
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewUpdatePlayerFlag(UpdateTimeOffset?: number): void;
+/**
+ * Updates the room data if needed
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewUpdateRoomSync(): void;
+/**
+ * Updates the player map data if needed
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewUpdatePlayerSync(): void;
+/**
+ * Updates a character's map data
+ * @param {ServerMapDataResponse} data - Data object containing the new character map data.
+ * @returns {void} - Nothing.
+ */
+declare function ChatRoomMapViewSyncMapData(data: ServerMapDataResponse): void;
+/**
+ * Updates the player last map data if needed
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewUpdateLastMapDataSync(): void;
+/**
+ * Processes the character movement when the timer has expired
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewMovementProcess(): void;
+/**
+ * Checks if the player is leashed and if she should follow the leash holder
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewLeash(): void;
+/**
+ * Draws the map and characters of the chat room map on the left side of the screen
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewDraw(): void;
+/**
+ * Draws the buttons of the chat room map
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewDrawUi(): void;
+/**
+ * Change the key of charachter - sender
+ * @param {Character} target
+ * @param {("gold" | "silver" | "bronze")[]} keys
+ */
+declare function ChatRoomMapViewChangeKey(target: Character, keys: ("gold" | "silver" | "bronze")[], boolean: any): void;
+/**
+ * Change a key from a character from a hidden message - reciver
+ * @param {Character} sender
+ * @param {ServerChatRoomMessage} data
+ */
+declare function ChatRoomMapViewChangeKeyHiddenMessage(sender: Character, data: ServerChatRoomMessage): void;
+/**
+ * Teleport a character to a specific tile
+ * @param {Character} target
+ * @param {ChatRoomMapPos} position
+ */
+declare function ChatRoomMapViewTeleport(target: Character, position: ChatRoomMapPos): void;
+/**
+ * Teleport a character to a specific tile from a hidden message
+ * @param {Character} sender
+ * @param {ServerChatRoomMessage} data
+ */
+declare function ChatRoomMapViewTeleportHiddenMessage(sender: Character, data: ServerChatRoomMessage): void;
+/**
+ * Check if a tile on the map can be entered by a player, and return the number of milliseconds required to reach it
+ * @param {number} X - The X position on the map
+ * @param {number} Y - The Y position on the map
+ * @returns {number} - The number of milliseconds
+ */
+declare function ChatRoomMapViewCanEnterTile(X: number, Y: number): number;
+/**
+ * Moves the player
+ * @param {"West" | "East" | "North" | "South"} D - The direction being travelled (North, South, East, West)
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewMove(D: "West" | "East" | "North" | "South"): void;
+/**
+ * Undoes the changes made to the map, from the latest backup in the stack
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewUndo(): void;
+declare function ChatRoomMapViewKeyDown(event: KeyboardEvent): boolean;
+declare function ChatRoomMapViewKeyUp(event: KeyboardEvent): boolean;
+/**
+ * Handles clicks the chatroom screen view.
+ * @returns {void} - Nothing.
+ */
+declare function ChatRoomMapViewClick(): void;
+/**
+ * Mouse down event is used to draw on screen and handle the tiles buttons
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewMouseDown(): void;
+/**
+ * Mouse move event is used to draw on screen
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewMouseMove(): void;
+declare function ChatRoomMapViewMouseUp(event: MouseEvent | TouchEvent): void;
+declare function ChatRoomMapViewMouseWheel(event: WheelEvent): void;
+/**
+ * Copies the current map in the clipboard.  Called from the chat field command "mapcopy"
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewCopy(): void;
+/**
+ * Pastes the current map Param data to load it.  Called from the chat field command "mappaste"
+ * @param {string} Param - The parameter that comes with the command
+ * @returns {void} - Nothing
+ */
+declare function ChatRoomMapViewPaste(Param: string): void;
+/**
+ * Converts the color in R [0; 255], G [0; 255], B [0; 255], A [0.0; 1.0] format
+ * to an HTML color function.
+ * @param {[number, number, number, number]} rgba
+ * @returns {string}
+ */
+declare function RgbaArrayToHTMLColor(rgba: [number, number, number, number]): string;
+declare const ChatRoomMapViewName: "Map";
+declare var ChatRoomMapViewWidth: number;
+declare var ChatRoomMapViewHeight: number;
+declare var ChatRoomMapViewPerceptionRange: number;
+declare var ChatRoomMapViewPerceptionRangeMin: number;
+declare var ChatRoomMapViewPerceptionRangeMax: number;
+declare var ChatRoomMapViewObjectStartID: number;
+declare var ChatRoomMapViewObjectEntryID: number;
+/** @type {"" |  "Tile" | "Object" | "TileType" | "ObjectType" | "Effect"} */
+declare var ChatRoomMapViewEditMode: "" | "Tile" | "Object" | "TileType" | "ObjectType" | "Effect";
+/** @type {"" | ChatRoomMapTileType | ChatRoomMapObjectType} */
+declare var ChatRoomMapViewEditSubMode: "" | ChatRoomMapTileType | ChatRoomMapObjectType;
+declare var ChatRoomMapViewEditStarted: boolean;
+/** @type {null | ChatRoomMapDoodad | ChatRoomMapEffect} */
+declare var ChatRoomMapViewEditObject: null | ChatRoomMapDoodad | ChatRoomMapEffect;
+/** @type {number[]} */
+declare var ChatRoomMapViewEditSelection: number[];
+declare var ChatRoomMapViewEditRange: number;
+/** @type {ServerChatRoomMapData[]} */
+declare var ChatRoomMapViewEditBackup: ServerChatRoomMapData[];
+/** @type {null | number} */
+declare var ChatRoomMapViewUpdateRoomNext: null | number;
+/** @type {null | number} */
+declare var ChatRoomMapViewUpdatePlayerNext: null | number;
+/** @type {null | number} */
+declare var ChatRoomMapViewUpdateLastMapDataNext: null | number;
+/** @type {null | Character} */
+declare var ChatRoomMapViewFocusedCharacter: null | Character;
+declare var ChatRoomMapViewFocusedCharacterX: number;
+declare var ChatRoomMapViewFocusedCharacterY: number;
+declare var ChatRoomMapViewSuperPowersActive: boolean;
+declare var ChatRoomMapViewBaseMovementSpeed: number;
+/** @type {null | ChatRoomMapMovement} */
+declare var ChatRoomMapViewMovement: null | ChatRoomMapMovement;
+/** @type {ChatRoomMapType[]} */
+declare var ChatRoomMapViewTypeList: ChatRoomMapType[];
+declare var ChatRoomMapViewUpdatePlayerTime: number;
+declare const ChatRoomMapViewPerceptionRaycastOffset: 0.4999;
+declare const ChatRoomMapViewWhisperRange: 1;
+declare const ChatRoomMapViewInteractionRange: 1;
+declare const ChatRoomMapViewRemoteRange: number;
+/** @type {boolean[]} */
+declare var ChatRoomMapViewVisibilityMask: boolean[];
+/** @type {boolean[]} */
+declare var ChatRoomMapViewAudibilityMask: boolean[];
+declare var ChatRoomMapViewTileFog: string;
+declare var ChatRoomMapViewObjectFog: string;
+declare namespace ChatRoomMapViewKeysPressed {
+    let u: boolean;
+    let d: boolean;
+    let l: boolean;
+    let r: boolean;
+}
+declare var ChatRoomMapViewStartOfKeyPress: number;
+declare const ChatRoomMapViewEffectStartID: 10;
+/**
+ * A list of predefined lighting effects. May be replaced with a color picker in the future.
+ * @type {ChatRoomMapEffect[]}
+ * */
+declare const ChatRoomMapViewEffectList: ChatRoomMapEffect[];
+/** @type {ChatRoomMapTile[]} */
+declare const ChatRoomMapViewTileList: ChatRoomMapTile[];
+/** @type {ChatRoomMapObject[]} */
+declare const ChatRoomMapViewObjectList: ChatRoomMapObject[];
+declare namespace ChatRoomMapManager {
+    export let Map: {
+        /**
+         * @type {MapData}
+         * private
+         */
+        _mapData: {
+            /**
+             * @type {ChatRoomMapEffect[][]}
+             */
+            effects: ChatRoomMapEffect[][];
+            /**
+             * Removes all effects from the map.
+             */
+            removeAllEffects(): void;
+        };
+        /**
+         * @type {number}
+         * private
+         */
+        _dirtyFlags: number;
+        /**
+         * Get the current active effects array at a given coordinates.
+         * @param {number} x
+         * @param {number} y
+         * @returns {ChatRoomMapEffect[]}
+         */
+        getEffectsByXY(x: number, y: number): ChatRoomMapEffect[];
+        /**
+         * Get the current active effects array at a given tile index.
+         * @param {number} tileIndex the index of a map tile, as returned by ChatRoomMapViewCoordinatesToIndex.
+         * @returns {ChatRoomMapEffect[]}
+         */
+        getEffectsByIndex(tileIndex: number): ChatRoomMapEffect[];
+        /**
+         * Sets the list of active effects at given coordinates.
+         * @param {number} x
+         * @param {number} y
+         * @param {ChatRoomMapEffect[]} effects
+         * @returns {void}
+         */
+        setEffectsByXY(x: number, y: number, effects: ChatRoomMapEffect[]): void;
+        /**
+         * Sets the list of active effects at a given tile index.
+         * @param {number} tileIndex
+         * @param {ChatRoomMapEffect[]} effects
+         * @returns {void}
+         */
+        setEffectsByIndex(tileIndex: number, effects: ChatRoomMapEffect[]): void;
+        /**
+         * Clears the list of active effects at given coordinates.
+         * @param {number} x
+         * @param {number} y
+         * @returns {void}
+         */
+        clearEffectsByXY(x: number, y: number): void;
+        /**
+         * Clears the list of active effects at a given tile index.
+         * @param {number} tileIndex
+         * @returns {void}
+         */
+        clearEffectsByIndex(tileIndex: number): void;
+        /**
+         * Returns the effects list for each tile in the map, one array element per tile.
+         * Currently for efficiency does not copy the underlying array.
+         * The users must not modify the returned array directly.
+         * @return {ChatRoomMapEffect[][]}
+         */
+        getAllEffects(): ChatRoomMapEffect[][];
+        /**
+         * Replaces all current effects with the parsed effects array.
+         * For efficiency does not copy the passed effects.
+         * The users must not modify the passed effects array afterward.
+         * @param {ChatRoomMapEffect[][]} effectsList
+         * @returns {void}
+         */
+        replaceAllEffects(effectsList: ChatRoomMapEffect[][]): void;
+        /**
+         * Removes all effects from the map.
+         * @returns {void}
+         */
+        removeAllEffects(): void;
+        /**
+         * Mark a specific part of the map data as dirty, that is, changed and not yet synchronized with the server.
+         * @param {number} flag
+         * private
+         */
+        _markDirty(flag: number): void;
+        /**
+         * Marks a specific part of the map data as clean, that is, synchronized with the server.
+         * @returns {void}
+         */
+        _markClean(flag: any): void;
+        /**
+         * Marks the current effects data as dirty, that is, changed and not yet synchronized with the server.
+         * @returns {void}
+         */
+        markDirtyEffects(): void;
+        /**
+         * Marks the current effects data as clean, that is, synchronized with the server.
+         * @returns {void}
+         */
+        markCleanEffects(): void;
+        /**
+         * Checks whether the current effects data is dirty, that is, whether it needs
+         * to be synchronized with the server.
+         * @returns {boolean}
+         */
+        isDirtyEffects(): boolean;
+        /**
+         * Marks the current tiles data as dirty, that is, changed and not yet synchronized with the server.
+         * @returns {void}
+         */
+        markDirtyTiles(): void;
+        /**
+         * Marks the current tiles data as clean, that is, synchronized with the server.
+         * @returns {void}
+         */
+        markCleanTiles(): void;
+        /**
+         * Checks whether the current tiles data is dirty, that is, whether it needs
+         * to be synchronized with the server.
+         * @returns {boolean}
+         */
+        isDirtyTiles(): boolean;
+        /**
+         * Marks the current objects data as dirty, that is, changed and not yet synchronized with the server.
+         * @returns {void}
+         */
+        markDirtyObjects(): void;
+        /**
+         * Marks the current objects data as clean, that is, synchronized with the server.
+         * @returns {void}
+         */
+        markCleanObjects(): void;
+        /**
+         * Checks whether the current objects data is dirty, that is, whether it needs
+         * to be synchronized with the server.
+         * @returns {boolean}
+         */
+        isDirtyObjects(): boolean;
+        /**
+         * Mark all data in the current map as clean.
+         * @returns {void}
+         */
+        markCleanAll(): void;
+        /**
+         * Exports the current map data, including the tiles/objects,
+         * as a string that could be copied and stored by the players.
+         * @returns {string | undefined} the exported string, or `undefined`
+         * if there was an error while exporting the map.
+         */
+        exportString(): string | undefined;
+        /**
+         * Imports the map string that was exported earlier with {@link MapManager.exportString}
+         * method.
+         *
+         * This method must be as much compatible as possible, recovering as much information
+         * as possible from the exported map strings from any previous version of the game
+         * to prevent the players losing their stored maps.
+         *
+         * This method modifies the state of the current map and returns `true` in case of a successful import.
+         * If the string is malformed and cannot be parsed, the method returns `false` and doesn't modify
+         * any state.
+         * @param {string} mapString
+         * @returns {boolean} `true` if the string was successfully parsed and the current map data is updated,
+         * `false` otherwise
+         */
+        importString(mapString: string): boolean;
+        /**
+         * Encodes the current map data and updates the global {@link ChatRoomData.MapData} value.
+         * This function must be called after the map was changed and before it is sent to the server.
+         * Ideally we want to have a single function to build the encoded map data only
+         * when required, but it would require a significant API change of the outside code.
+         *
+         * For places where the synchronization happens, see {@link ChatRoomGetSettings} usages.
+         *
+         * This function is not supposed to fail; if it indicates an error by returning `false`,
+         * this means we have a bug in our code.
+         * @return {boolean} `true` if we successfully encoded the map data; `false` if
+         * there was an error and the global state remains unchanged.
+         */
+        updateGlobalMapData(): boolean;
+        /**
+         * Loads the data from {@link ChatRoomData.MapData} and replaces the current map data with the one
+         * stored in it.
+         * @return {boolean} `true` if the global map data was parsed successfully. `false` if
+         * the global map data is invalid, no data is changed in this case.
+         */
+        loadGlobalMapData(): boolean;
+        /**
+         * @returns {string | undefined}
+         * private
+         */
+        _encodeEffects(): string | undefined;
+        /**
+         * @param {string | undefined} str
+         * @returns {ChatRoomMapEffect[][] | undefined}
+         * private
+         */
+        _decodeEffects(str: string | undefined): ChatRoomMapEffect[][] | undefined;
+    };
+    export { OnMapDataUpdated };
+    export { OnViewActivate };
+}
+/**
+ * This function should be called each time the external code updates {@link ChatRoomData.MapData}.
+ *
+ * This function decodes the updated map data and replaces
+ * the data stored in ${@link ChatRoomMapManager.Map} with the decoded map.
+ * @returns {void}
+ */
+declare function OnMapDataUpdated(): void;
+/**
+ * Initializes the map with the current global data if needed.
+ * Must be called in {@link ChatRoomMapViewActivate}.
+ * @returns {void}
+ */
+declare function OnViewActivate(): void;

--- a/bc/Screens/Online/ChatRoom/Commands.d.ts
+++ b/bc/Screens/Online/ChatRoom/Commands.d.ts
@@ -141,7 +141,7 @@ declare let CommandsKey: string;
 declare let CommandText: TextCache;
 declare namespace CommandsHelp {
     /**
-     * @private
+     * private
      * @param {HTMLElement} help
      */
     function _Publish(help: HTMLElement): void;

--- a/bc/Screens/Room/Crafting/Crafting.d.ts
+++ b/bc/Screens/Room/Crafting/Crafting.d.ts
@@ -341,7 +341,7 @@ declare namespace CraftingEventListeners {
 }
 declare namespace CraftingElements {
     /**
-     * @private
+     * private
      * @param {string} id
      * @param {string} controls
      * @param {string} placeholder
@@ -350,7 +350,7 @@ declare namespace CraftingElements {
     function _SearchInput(id: string, controls: string, placeholder: string, assetSearch?: boolean): HTMLInputElement;
     let _SearchCache: Map<"ALL" | AssetGroupItemName, readonly HTMLOptionElement[]>;
     /**
-     * @private
+     * private
      * @param {string} id
      * @param {(this: HTMLButtonElement, ev: Event) => any} onClick
      * @param {null | Asset} asset

--- a/bc/Screens/Room/Crafting/CraftingJSON.d.ts
+++ b/bc/Screens/Room/Crafting/CraftingJSON.d.ts
@@ -11,7 +11,7 @@ declare namespace CraftingJSON {
         dragstart: (this: HTMLElement, ev: DragEvent) => void;
     };
     /**
-     * @private
+     * private
      * @param {Element} fieldset
      * @param {Element} radioContainer
      * @param {Map<{ inputNew: HTMLInputElement, inputOld: HTMLInputElement }, boolean>} checkLog

--- a/bc/Screens/Room/Shop2/Shop2.d.ts
+++ b/bc/Screens/Room/Shop2/Shop2.d.ts
@@ -34,7 +34,7 @@ declare const Shop2Vars: VariableContainer<{
     Push: boolean;
     /**
      * The current shop mode
-     * @private
+     * private
      * @type {ShopMode}
      */
     _Mode: ShopMode;
@@ -148,18 +148,18 @@ declare namespace Shop2Consts {
 declare namespace Shop2 {
     /**
      * Populate {@link Shop2Consts.BuyGroups} with buy groups.
-     * @private
+     * private
      */
     function _PopulateBuyGroups(): void;
     /**
      * Populate {@link Shop2InitVars.GroupDescriptions} with group descriptions and all corresponding group names
      * @param {readonly ShopItem[]} assets
-     * @private
+     * private
      */
     function _PopulateGroupDescriptions(assets: readonly ShopItem[]): void;
     /**
      * Populate {@link Shop2Consts.Keys} and {@link Shop2Consts.Remote} with the name of all asset keys and remotes.
-     * @private
+     * private
      */
     function _PopulateKeysAndRemotes(): void;
     /**
@@ -170,7 +170,7 @@ declare namespace Shop2 {
      * @param {number} h
      * @param {number} assetIndex - The assets index within {@link Shop2Vars.CurrentAssets}
      * @satisfies {ScreenDrawHandler}
-     * @private
+     * private
      */
     function _AssetElementDraw(x: number, y: number, w: number, h: number, assetIndex: number): void;
     /**
@@ -178,7 +178,7 @@ declare namespace Shop2 {
      * @param {MouseEvent | TouchEvent} event
      * @param {number} assetIndex - The assets index within {@link Shop2Vars.CurrentAssets}
      * @satisfies {MouseEventListener}
-     * @private
+     * private
      */
     function _AssetElementClick(event: MouseEvent | TouchEvent, assetIndex: number): void;
     /**

--- a/bc/Scripts/BitString.d.ts
+++ b/bc/Scripts/BitString.d.ts
@@ -229,9 +229,9 @@ declare class BitStringWriter {
     /**
      * The current buffer: an array of 16-bit unsigned integers representing the bit stream this class writes to.
      * @type {number[]}
-     * @private
+     * private
      */
-    private _buffer;
+    _buffer: number[];
     /**
      * The amount of free bits in the last char of the {@link BitStringWriter._buffer}.
      *
@@ -243,9 +243,9 @@ declare class BitStringWriter {
      * back to {@link _BitStringHelperInternal.CHAR_BITS}.
      *
      * @type {number}
-     * @private
+     * private
      */
-    private _freeBitsLastChar;
+    _freeBitsLastChar: number;
     /**
      * Resets the current writer, discarding any data written so far.
      * @returns {this}
@@ -320,9 +320,9 @@ declare class BitStringWriter {
      * Writes an unsigned value without bit-width checks.
      * @param {number} value
      * @param {number} bits
-     * @private
+     * private
      */
-    private _writeUnsignedValueNoChecks;
+    _writeUnsignedValueNoChecks(value: number, bits: number): void;
     /**
      * Writes `value`, a `bits`-wide integer, to the free space in the last character being written.
      *
@@ -330,18 +330,18 @@ declare class BitStringWriter {
      *
      * @param {number} value
      * @param {number} bits
-     * @private
+     * private
      */
-    private _addBitsToBufferLastChar;
+    _addBitsToBufferLastChar(value: number, bits: number): void;
     /**
      * Adds a full `CHAR_BIT`-wide value to the buffer.
      *
      * The last char of the buffer must NOT contain any free bits.
      *
      * @param {number} value
-     * @private
+     * private
      */
-    private _pushFullCharToBuffer;
+    _pushFullCharToBuffer(value: number): void;
     /**
      * A specialized version of {@link BitStringWriter._addBitsToBufferLastChar}.
      * Instead of modifying the last char, it pushes a new one and writes {@link value}
@@ -351,15 +351,15 @@ declare class BitStringWriter {
      *
      * @param {number} value
      * @param {number} bits
-     * @private
+     * private
      */
-    private _pushPartCharToBuffer;
+    _pushPartCharToBuffer(value: number, bits: number): void;
     /**
      * An efficient way to add a single bit to the buffer.
      * @param {number} value
-     * @private
+     * private
      */
-    private _writeBitNoChecks;
+    _writeBitNoChecks(value: number): void;
 }
 /**
  * The reader class. It is responsible for reading packed integers from a BitString.
@@ -383,9 +383,9 @@ declare class BitStringReader {
     /**
      * The current buffer, representing the input bit stream.
      * @type {string}
-     * @private
+     * private
      */
-    private _buffer;
+    _buffer: string;
     /**
      * The index of the current char in the {@link BitStringReader._buffer}.
      *
@@ -393,15 +393,15 @@ declare class BitStringReader {
      * bit position in the input bit stream.
      *
      * @type {number}
-     * @private
+     * private
      */
-    private _charPos;
+    _charPos: number;
     /**
      * The amount of bits read from the current char. Always inside `[0; CHAR_BITS - 1]`.
      * @type {number}
-     * @private
+     * private
      */
-    private _bitPosLastChar;
+    _bitPosLastChar: number;
     /**
      * Reads an unsigned integer from the reader. Throws an *Invalid argument* error if
      * there is not enough data left to read full {@link bits} bits.
@@ -506,9 +506,9 @@ declare class BitStringReader {
      *
      * @param {number} bits
      * @returns {number}
-     * @private
+     * private
      */
-    private _readBitsLastChar;
+    _readBitsLastChar(bits: number): number;
     /**
      * Reads a full {@link _BitStringHelperInternal.CHAR_BITS}-bits unsigned integer
      * from the current char, and advances to the next one.
@@ -516,17 +516,17 @@ declare class BitStringReader {
      * Must only be called when {@link BitStringReader._bitPosLastChar} === 0.
      *
      * @returns {number}
-     * @private
+     * private
      */
-    private _readFullChar;
+    _readFullChar(): number;
     /**
      * A faster way of reading a single bit.
      *
      * @returns {0 | 1 | undefined} 0, 1, or `undefined`, the latter indicating
      * there is no more data to read.
-     * @private
+     * private
      */
-    private _tryReadBitFast;
+    _tryReadBitFast(): 0 | 1 | undefined;
     /**
      * Advances the current bit position in the buffer.
      *
@@ -536,13 +536,13 @@ declare class BitStringReader {
      * of {@link BitStringReader._buffer}, which indicates that there is no more data to read.
      *
      * @param {number} bits how many bits to advance.
-     * @private
+     * private
      */
-    private _advanceBits;
+    _advanceBits(bits: number): void;
     /**
      * @returns {number} the amount of bits available for reading in the current char.
      * Always > 0, even if {@link BitStringReader.overflown} is `true`.
-     * @private
+     * private
      */
-    private get _unreadBitsLastChar();
+    get _unreadBitsLastChar(): number;
 }

--- a/bc/Scripts/ColorPicker.d.ts
+++ b/bc/Scripts/ColorPicker.d.ts
@@ -122,7 +122,7 @@ declare namespace ColorPicker {
     }
     /**
      * Unpack and validate the {@link HTMLFieldSetElement.elements} of the passed `fieldset[name='color-picker']` element.
-     * @private
+     * private
      * @param {HTMLFieldSetElement} fieldset
      * @param {null | { checkValidity?: boolean }} options
      */
@@ -155,7 +155,7 @@ declare namespace ColorPicker {
     function create(id: null | string, options?: null | Pick<ColorPickerInitOptions, "colorState" | "onInput">): HTMLFieldSetElement;
     /**
      * {@link ColorPicker.setColor} helper for parsing color values (be it stringified or as HSV)
-     * @private
+     * private
      * @param {Pick<ColorPickerColorInput, "colorString" | "hsv">} value
      * @param {HTMLInputElement} outputInput
      * @param {null | number} opacity
@@ -167,7 +167,7 @@ declare namespace ColorPicker {
     };
     /**
      * {@link ColorPicker.setColor} helper for parsing opacity values
-     * @private
+     * private
      * @param {Pick<ColorPickerColorInput, "opacity" | "colorString">} value
      * @param {HTMLInputElement} opacityInput
      * @param {null | { overrideEditOpacity?: boolean }} options

--- a/bc/Scripts/Dialog.d.ts
+++ b/bc/Scripts/Dialog.d.ts
@@ -996,10 +996,10 @@ declare class DialogMenu<ModeType extends string = string, ClickedObj = any, Pro
     readonly clickStatusCallbacks: Record<string, DialogMenu<string, ClickedObj>["GetClickStatus"]>;
     /**
      * See {@link DialogMenu.shape}
-     * @private
+     * private
      * @type {null | RectTuple}
      */
-    private _shape;
+    _shape: null | RectTuple;
     set shape(value: RectTuple);
     /**
      * Get or set the position & shape of the current subscreen as defined by the root element.
@@ -1033,25 +1033,25 @@ declare class DialogMenu<ModeType extends string = string, ClickedObj = any, Pro
     /**
      * A set with the numeric IDs of to-be run reloads.
      * See {@link DialogMenu.Reload}
-     * @private
+     * private
      * @readonly
      * @type {Set<number>}
      */
-    private readonly _reloadQueue;
+    readonly _reloadQueue: Set<number>;
     /**
      * The highest reload ID currently in use.
      * See {@link DialogMenu.Reload}
-     * @private
+     * private
      * @type {number}
      */
-    private _reloadHighestID;
+    _reloadHighestID: number;
     /**
      * Promise object for queuing reloads, ensuring that they are run consecutively rather than concurrently if multiple calls are invoked (near) simultaneously.
      * See {@link DialogMenu.Reload}
-     * @private
+     * private
      * @type {Promise<boolean>}
      */
-    private _reloadPromise;
+    _reloadPromise: Promise<boolean>;
     /**
      * Initialize the {@link DialogMenu} subscreen.
      *
@@ -1369,16 +1369,16 @@ declare class _DialogDialogMenu<T extends string> extends DialogMenu<T, DialogLi
     };
     /**
      * A {@link clearTimeout}-returned ID for temporarily disabling the exit button on mobile button clicks
-     * @private
+     * private
      * @type {null | number}
      */
-    private _mobileTimeoutID;
+    _mobileTimeoutID: null | number;
     /**
-     * @private
+     * private
      * @param {Character} C
      * @satisfies {TimerHandler}
      */
-    private _mobileTimeoutHandler;
+    _mobileTimeoutHandler(C: Character): void;
     /**
      * A {@link DialogMenu.Reload} helper function for reloading {@link DialogMenu.ids.status} elements.
      * @abstract
@@ -1477,10 +1477,10 @@ declare class _DialogExpressionMenu<ModeType extends DialogSelfMenuName> extends
     };
     /**
      * See {@link _DialogExpressionMenu.facialExpressions}
-     * @private
+     * private
      * @type {null | Readonly<Partial<Record<ExpressionGroupName, readonly (null | ExpressionName)[]>>>}
      */
-    private _facialExpressions;
+    _facialExpressions: null | Readonly<Partial<Record<ExpressionGroupName, readonly (null | ExpressionName)[]>>>;
     /**
      * Get an object with all UI-configurable expression group names mapped to their respective expressions.
      * @type {Readonly<Partial<Record<ExpressionGroupName, readonly (null | ExpressionName)[]>>>}
@@ -1571,10 +1571,10 @@ declare class _DialogPoseMenu<ModeType extends DialogSelfMenuName> extends _Dial
     };
     /**
      * See {@link poses}
-     * @private
+     * private
      * @type {null | Readonly<Partial<Record<AssetPoseCategory, readonly Pose[]>>>}
      */
-    private _poses;
+    _poses: null | Readonly<Partial<Record<AssetPoseCategory, readonly Pose[]>>>;
     /**
      * An object mapping all (potentially) button-valid pose categories to their respective poses.
      * @type {Readonly<Partial<Record<AssetPoseCategory, readonly Pose[]>>>}
@@ -1637,10 +1637,10 @@ declare class _DialogSavedExpressionsMenu<ModeType extends DialogSelfMenuName> e
     clickStatusCallbacks: DialogMenu<ModeType, number>["clickStatusCallbacks"];
     /**
      * See {@link expressionPreviews}
-     * @private
+     * private
      * @type {null | (null | Character)[]}
      */
-    private _expressionPreviews;
+    _expressionPreviews: null | (null | Character)[];
     /**
      * @type {readonly (null | Character)[]}
      */

--- a/bc/Scripts/DictionaryBuilder.d.ts
+++ b/bc/Scripts/DictionaryBuilder.d.ts
@@ -228,17 +228,17 @@ declare class DictionaryBuilder {
      * Adds a dictionary entry to the builder
      * @param {ChatMessageDictionaryEntry} entry - The dictionary entry to add
      * @returns {boolean} - True if the entry was successfully added, false otherwise
-     * @protected
+     * protected
      */
-    protected _addEntry(entry: ChatMessageDictionaryEntry): boolean;
+    _addEntry(entry: ChatMessageDictionaryEntry): boolean;
     /**
      * Adds a character reference dictionary entry for the given character reference tag and character.
      * @param {CharacterReferenceTag} tag - The character reference tag that should be added
      * @param {Character} character - The character that should be referenced
      * @returns {this}
-     * @private
+     * private
      */
-    private _addCharacterReference;
+    _addCharacterReference(tag: CharacterReferenceTag, character: Character): this;
 }
 /**
  * A {@link DictionaryBuilder} class which adds its dictionary entries based on a boolean condition. If the condition

--- a/bc/Scripts/Element.d.ts
+++ b/bc/Scripts/Element.d.ts
@@ -417,7 +417,7 @@ declare namespace ElementButton {
     function _KeyDownRadio(this: HTMLElement, ev: KeyboardEvent): void;
     function _ClickCheckbox(this: HTMLButtonElement, ev: Event): void;
     /**
-     * @private
+     * private
      * @param {string} id
      * @param {string} [img]
      * @param {null | string} [imgColor]
@@ -426,7 +426,7 @@ declare namespace ElementButton {
      */
     function _ParseImage(id: string, img?: string, imgColor?: null | string, options?: Omit<HTMLOptions<"img" | "div">, "tag">): HTMLImageElement | HTMLDivElement | null;
     /**
-     * @private
+     * private
      * @param {string} id
      * @param {ElementButton.StaticNode} [label]
      * @param {"top" | "center" | "bottom" | "left" | "right"} [position]
@@ -445,7 +445,7 @@ declare namespace ElementButton {
         tooltip: [string, HTMLElement];
     };
     /**
-     * @private
+     * private
      * @param {string} id
      * @param {"left" | "right" | "top" | "bottom"} [position]
      * @param {readonly (null | undefined | string | Node | HTMLOptions<any>)[]} [children]
@@ -501,7 +501,7 @@ declare namespace ElementButton {
 declare namespace ElementMenu {
     export let _observers: WeakMap<Element, MutationObserver>;
     /**
-     * @private
+     * private
      * @satisfies {MutationCallback}
      * @param {readonly { addedNodes: readonly Node[] | NodeList, target: Node }[]} mutationList
      */
@@ -634,7 +634,7 @@ declare namespace ElementDOMScreen {
     let _statusIDMap: WeakMap<Element, number>;
     /**
      * Timer handler for {@link ElementDOMScreen.SetStatus}
-     * @private
+     * private
      * @satisfies {TimerHandler}
      * @param {Element} headingElem The screen's `h1` element
      * @param {Element} statusElem The screen's `[role='status']` element
@@ -668,10 +668,10 @@ declare class HTMLColorTintElement extends HTMLElement {
     /** @type {null | ElementInternals} */
     internals_: null | ElementInternals;
     /**
-     * @private
+     * private
      * @type {null | string}
      */
-    private _pressedOldValue;
+    _pressedOldValue: null | string;
     connectedCallback(): void;
     /**
      * Sets or retrieves the initial contents of the object.
@@ -747,10 +747,10 @@ declare class HTMLColorTintElement extends HTMLElement {
      */
     reportValidity(): boolean;
     /**
-     * @private
+     * private
      * @type {Readonly<HSVColor>}
      */
-    private _value;
+    _value: Readonly<HSVColor>;
     set name(value: string);
     /**
      * Sets or retrieves the name of the object.
@@ -761,15 +761,18 @@ declare class HTMLColorTintElement extends HTMLElement {
     get name(): string;
     /**
      * Set the position the knob
-     * @private
+     * private
      * @param {number} left - The relative left position on a scale of 0-100
      * @param {number} top - The relative top position on a scale of 0-100
      */
-    private _setKnobPosition;
+    _setKnobPosition(left: number, top: number): void;
     /**
      * Get the position the knob
-     * @private
+     * private
      * @returns {{ left: number, top: number }} - The position of the knob on a scale of 0-100
      */
-    private _getKnobPosition;
+    _getKnobPosition(): {
+        left: number;
+        top: number;
+    };
 }

--- a/bc/Scripts/Inventory.d.ts
+++ b/bc/Scripts/Inventory.d.ts
@@ -546,7 +546,7 @@ declare function InventoryExtractLockProperties(property: ItemProperties): ItemP
 declare namespace InventoryPrerequisiteConflicts {
     let GagPriorities: Partial<Record<AssetGroupName, number>>;
     /**
-     * @private
+     * private
      * @template {keyof PropertiesArray} T
      * @param {T} fieldName
      * @param {Character} C - The character on which we check for prerequisites

--- a/bc/Scripts/KeybindingManager.d.ts
+++ b/bc/Scripts/KeybindingManager.d.ts
@@ -97,14 +97,14 @@ declare namespace KeybindingManager {
  * Handles registration, updates, serialization, and event handling.
  */
 declare class KeybindManager {
-    /** @private @type {Map<string, Keybindings.Keybinding>} */
-    private keybindings;
-    /** @private @type {Map<string, Keybindings.Category>} */
-    private categories;
-    /** @private @type {Map<string, Keybindings.Context>} */
-    private contexts;
-    /** @private @type {Map<string, Keybindings.UninitializedKeybinding>} */
-    private uninitializedKeybindings;
+    /** private @type {Map<string, Keybindings.Keybinding>} */
+    keybindings: Map<string, Keybindings.Keybinding>;
+    /** private @type {Map<string, Keybindings.Category>} */
+    categories: Map<string, Keybindings.Category>;
+    /** private @type {Map<string, Keybindings.Context>} */
+    contexts: Map<string, Keybindings.Context>;
+    /** private @type {Map<string, Keybindings.UninitializedKeybinding>} */
+    uninitializedKeybindings: Map<string, Keybindings.UninitializedKeybinding>;
     /**
      * Registers a new keybinding category.
      * Categories are sorted alphabetically by name after insertion.
@@ -259,35 +259,35 @@ declare class KeybindManager {
      * Completes the registration of an uninitialized keybinding.
      * Used when a binding exists in storage but not in defaults at load time.
      *
-     * @private
+     * private
      * @param {Keybindings.Keybinding} keybinding
      * @return {Keybindings.Keybinding}
      */
-    private _finishUninitializedKeybinding;
+    _finishUninitializedKeybinding(keybinding: Keybindings.Keybinding): Keybindings.Keybinding;
     /**
      * Checks if two modifier sets match exactly.
      *
-     * @private
+     * private
      * @param {Set<Keybindings.ModifierKey>} modifiers1
      * @param {Set<Keybindings.ModifierKey>} modifiers2
      * @returns {boolean}
      */
-    private _areModifiersConflicting;
+    _areModifiersConflicting(modifiers1: Set<Keybindings.ModifierKey>, modifiers2: Set<Keybindings.ModifierKey>): boolean;
     /**
      * Checks if two context sets match exactly.
      *
-     * @private
+     * private
      * @param {Set<string>} contexts1
      * @param {Set<string>} contexts2
      * @returns {boolean}
      */
-    private _areContextsConflicting;
+    _areContextsConflicting(contexts1: Set<string>, contexts2: Set<string>): boolean;
     /**
      * Registers an uninitialized keybinding.
      *
-     * @private
+     * private
      * @param {Keybindings.UninitializedKeybinding} keybinding
      */
-    private _registerUninitializedKeybinding;
+    _registerUninitializedKeybinding(keybinding: Keybindings.UninitializedKeybinding): void;
 }
 declare var KeyManager: KeybindManager;

--- a/bc/Scripts/Layering.d.ts
+++ b/bc/Scripts/Layering.d.ts
@@ -29,32 +29,32 @@ declare namespace Layering {
     }>;
     let _ExitCallbacks: ((screen: string, C: Character, item: Item) => void)[];
     /**
-     * @private
+     * private
      * Initialize the object-based variant of {@link AssetLayerOverridePriority}
      */
     function _InitOverridePriorityObject(): void;
     /**
-     * @private
+     * private
      * @param {string} name - The name of the layer
      * @param {number} priority - The stringified layer priority
      * @param {string} defaultPriority - The stringified default priority of the layer
      */
     function _ApplyLayerPriority(name: string, priority: number, defaultPriority: string): void;
     /**
-     * @private
+     * private
      * @param {number} priority - The layer priority
      * @param {string} defaultPriority - The stringified default priority of the layer
      */
     function _ApplyAssetPriority(priority: number, defaultPriority: string): void;
     /**
      * Event listener for `input` events involving layer priorities
-     * @private
+     * private
      * @param {Event} event
      */
     function _LayerInputListener(event: Event): void;
     /**
      * Event listener for `input` events involving asset priorities
-     * @private
+     * private
      * @param {Event} event
      */
     function _AssetInputListener(event: Event): void;
@@ -63,25 +63,25 @@ declare namespace Layering {
      * Event listener for `click` events of the reset button
      * @this {HTMLButtonElement}
      * @param {Event} ev
-     * @private
+     * private
      */
     function _ResetClickListener(this: HTMLButtonElement, ev: Event): void;
     /**
      * Event listener for `click` events of the show hidden layers button
      * @this {HTMLButtonElement}
      * @param {Event} ev
-     * @private
+     * private
      */
     function _ShowLayersClickListener(this: HTMLButtonElement, ev: Event): void;
     /**
      * Update the background colors of the `number`-based input elements, the color change depending on whether one is changing an asset- or layer-specific priority.
-     * @private
+     * private
      * @param {"layer-priority" | "asset-priority"} activeType
      */
     function _UpdateInputColors(activeType: "layer-priority" | "asset-priority"): void;
     /**
      * Group all layers by their {@link AssetLayer.CopyLayerColor} properties
-     * @private
+     * private
      * @param {readonly AssetLayer[]} layers
      * @returns {Record<string, AssetLayer[]>}
      */
@@ -90,14 +90,14 @@ declare namespace Layering {
      * Return the default `Property.OverridePriority` of the current item.
      *
      * This is generally `undefined`, though certain extended item options do overwrite it.
-     * @private
+     * private
      * @returns {undefined | AssetLayerOverridePriority}
      */
     function _GetDefaultPriority(): undefined | AssetLayerOverridePriority;
     /**
      * Update all input elements and buttons with the passed {@link Layering.Readonly} status.
      * @param {boolean} isReadonly
-     * @private
+     * private
      */
     function _ApplyReadonly(isReadonly: boolean): void;
     /**

--- a/bc/Scripts/Server.d.ts
+++ b/bc/Scripts/Server.d.ts
@@ -298,7 +298,7 @@ declare var ServerAccountUpdate: {
     QueueData(Data: ServerAccountUpdateRequest, Force?: boolean): void;
 };
 /**
- * @private Use the {@link ServerIsLoggedIn} function instead.
+ * private Use the {@link ServerIsLoggedIn} function instead.
  * @type {boolean}
  */
 declare let ServerIsLoggedIn_: boolean;

--- a/bc_data/package.json
+++ b/bc_data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-data",
-  "version": "125.0.0",
+  "version": "125.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bc-stubs",
-  "version": "125.0.0",
+  "version": "125.0.1",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/bananarama92/BC-stubs.git"

--- a/remove_private_protected.py
+++ b/remove_private_protected.py
@@ -1,0 +1,38 @@
+"""
+Remove all mentions of `@private` and `@protected` from the .js/.ts files in the passed directory.
+
+Used as a crutch for dealing with TS's lack of support for aforementioned JSDoc tags in combination
+with anonymous classes (xref https://github.com/microsoft/TypeScript/issues/30355).
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import os
+
+
+def main(root: str | os.PathLike[str]) -> None:
+    file_iter = itertools.chain.from_iterable(
+        [os.path.join(dir_path, i) for i in files if (i.endswith(".js") or i.endswith(".ts"))]
+        for (dir_path, _, files) in os.walk(root)
+    )
+
+    for path in file_iter:
+        with open(path, "r", encoding="utf8") as f_inp:
+            text_inp = f_inp.read()
+        if ("@protected" in text_inp or "@private" in text_inp):
+            with open(path, "w", encoding="utf8") as f_out:
+                f_out.write(text_inp.replace("@protected", "protected").replace("@private", "private"))
+
+
+if __name__ == "__main__":
+    description = None if __doc__ is None else __doc__.splitlines()[1]
+    parser = argparse.ArgumentParser(
+        usage="python ./remove_private_protected.py ./BondageClub",
+        description=description,
+    )
+    parser.add_argument("path", help="Path to the BC root directory")
+    args = parser.parse_args()
+    main(args.path)


### PR DESCRIPTION
Strip out all JSDoc `@private`/`@protected` tags as a crutch for dealing with TS's lack of support of them in combination with anonymous classes (xref https://github.com/microsoft/TypeScript/issues/30355). Limiting this nuclear option specifically to _anonymous_ classes would be ideal, there is no easy way of automating this process and manual fixups are very much judged as non desirable.